### PR TITLE
price homepage references v1

### DIFF
--- a/api/prices-api.md
+++ b/api/prices-api.md
@@ -1,2 +1,8 @@
+---
+description: Prices API documentation
+---
+
 # Prices API
 
+Includes:
+* [HTTP API (v1)](prices/v1.md)


### PR DESCRIPTION
- `api/prices-api.md` was blank previously, point to v1