### PR TITLE
Improve Rust example so it compiles and works as-is

### DIFF
--- a/sdks/rust-sdk/README.md
+++ b/sdks/rust-sdk/README.md
@@ -28,13 +28,13 @@ spice-rs = { git = "https://github.com/spiceai/spice-rs", tag = "v1.0.2" }
 ```rust
 use spice_rs::Client;
 
-let client = Client::new("API_KEY").await;
+let mut client = Client::new("API_KEY").await;
 ```
 
 2\. Execute a query and get back an Apache Arrow [Flight Record Batch Stream](https://arrow.apache.org/rust/arrow\_flight/decode/struct.FlightRecordBatchStream.html).
 
 ```rust
-let flight_data_stream = client.query("SELECT * FROM eth.recent_blocks LIMIT 10;").await.expect("Error executing query");
+let mut flight_data_stream = client.query("SELECT * FROM eth.recent_blocks LIMIT 10;").await.expect("Error executing query");
 ```
 
 3\. Iterate through the reader to access the records.
@@ -52,3 +52,7 @@ while let Some(batch) = flight_data_stream.next().await {
     };
 }
 ```
+{% hint style="info" %}
+Add [futures](https://docs.rs/futures/) crate and `use futures::StreamExt;` if you see `no method named next found for struct` compile error for `flight_data_stream.next()`.
+{% endhint %}
+


### PR DESCRIPTION
1.[ client.query](https://github.com/spiceai/spice-rs/blob/v1.0.2/src/client.rs#L45) requires mutable client => `let mut client` on Step 1.
2. [flight_data_stream.next() ](https://github.com/rust-lang/futures-rs/blob/f9f8e690504529c2813caadabd85506756f8dc67/futures-util/src/stream/stream/mod.rs#L249)is mutable => `let mut flight_data_stream` on Step 2.