### PR TITLE
Create .gitbook.yaml and setup copilot redirect

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -1,0 +1,4 @@
+root: ./
+
+redirects:
+  copilot: integrations/github-copilot.md


### PR DESCRIPTION
## 🗣 Description

This change creates a redirect from `/copilot` to `/integrations/github-copilot` so that users can easily access the GitHub Copilot documentation from a shorter link. 

## 🔨 Related Issues

## 🤔 Concerns