### PR TITLE
Remove Kubernetes references from API docs

### DIFF
--- a/api/management/apps.md
+++ b/api/management/apps.md
@@ -164,7 +164,7 @@ Creates a new app in the authenticated organization.
 | `update_channel`        | string         | `stable`, `nightly`, `internal`, or `internal-sandbox` |
 | `replicas`              | integer        | Number of replicas (1-10)                              |
 | `region`                | string \| null | AWS region code                                        |
-| `node_group`            | string \| null | Kubernetes node group                                  |
+| `node_group`            | string \| null | Node group for deployment                              |
 | `storage_claim_size_gb` | number \| null | Persistent volume size                                 |
 {% endtab %}
 
@@ -386,7 +386,7 @@ Updates an app's metadata and configuration. All fields are optional.
 | `update_channel`        | string           | `stable`, `nightly`, `internal`, or `internal-sandbox` |
 | `replicas`              | integer          | Number of replicas (1-10)                              |
 | `region`                | string           | AWS region code                                        |
-| `node_group`            | string           | Kubernetes node group                                  |
+| `node_group`            | string           | Node group for deployment                              |
 | `storage_claim_size_gb` | number           | Persistent volume size                                 |
 
 ### Response

--- a/api/management/deployments.md
+++ b/api/management/deployments.md
@@ -5,7 +5,7 @@ icon: rocket
 
 # Deployments API
 
-Deployments represent versions of your app that are deployed to the Spice runtime. Each deployment creates or updates a Kubernetes deployment with your app's spicepod configuration.
+Deployments represent versions of your app that are deployed to the Spice runtime. Each deployment creates or updates a running instance with your app's spicepod configuration.
 
 ## List Deployments
 

--- a/api/management/terraform.md
+++ b/api/management/terraform.md
@@ -124,7 +124,7 @@ resource "spiceai_app" "app" {
 | ------------ | ---------------------------------------------- |
 | `id`         | App ID                                         |
 | `api_key`    | Primary API key (sensitive)                    |
-| `cluster_id` | Kubernetes cluster identifier                  |
+| `cluster_id` | Cluster identifier                             |
 | `created_at` | Timestamp when the app was created             |
 
 The `spicepod` can also be provided as JSON or loaded from a template file:

--- a/building-blocks/data-connectors/s3.md
+++ b/building-blocks/data-connectors/s3.md
@@ -70,7 +70,7 @@ For CSV-specific parameters, see [CSV Parameters](../../reference/file-format.md
 
 ## Authentication
 
-No authentication is required for public endpoints. For private buckets, set s3_auth to key or iam_role. For Kubernetes Service Accounts with assigned IAM roles, set `s3_auth` to `iam_role`. If using iam_role, the [AWS IAM role](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html) of the running instance is used.
+No authentication is required for public endpoints. For private buckets, set s3_auth to key or iam_role. For environments with assigned IAM roles, set `s3_auth` to `iam_role`. If using iam_role, the [AWS IAM role](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html) of the running instance is used.
 
 Minimum IAM policy for S3 access:
 


### PR DESCRIPTION
## Summary
- Remove Kubernetes implementation details from API management docs (`apps.md`, `deployments.md`, `terraform.md`) and S3 connector auth docs
- Replace with generic terminology (e.g. "node group for deployment", "cluster identifier", "running instance")

## Test plan
- [ ] Verify docs render correctly on GitBook