### PR TITLE
Update management API docs: region field in create app api, remove internal fields

### DIFF
--- a/api/management/apps.md
+++ b/api/management/apps.md
@@ -29,7 +29,6 @@ Returns a list of apps for the authenticated organization.
       "visibility": "private",
       "created_at": "2024-01-15T10:00:00.000Z",
       "cname": "us-west-2-prod-aws-data",
-      "api_key": "abc123...",
       "tags": {
         "environment": "production",
         "team": "data"
@@ -41,16 +40,15 @@ Returns a list of apps for the authenticated organization.
 
 **Response Fields:**
 
-| Field         | Type           | Description                                  |
-| ------------- | -------------- | -------------------------------------------- |
-| `id`          | integer        | Unique app identifier                        |
-| `name`        | string         | App name                                     |
-| `description` | string \| null | App description                              |
-| `visibility`  | string         | `public` or `private`                        |
-| `created_at`  | string         | ISO 8601 timestamp                           |
-| `cname`       | string         | Region identifier                            |
-| `api_key`     | string \| null | Primary API key (for runtime authentication) |
-| `tags`        | object \| null | Key-value tags                               |
+| Field         | Type           | Description            |
+| ------------- | -------------- | ---------------------- |
+| `id`          | integer        | Unique app identifier  |
+| `name`        | string         | App name               |
+| `description` | string \| null | App description        |
+| `visibility`  | string         | `public` or `private`  |
+| `created_at`  | string         | ISO 8601 timestamp     |
+| `cname`       | string         | Region identifier      |
+| `tags`        | object \| null | Key-value tags         |
 {% endtab %}
 
 {% tab title="401: Unauthorized" %}
@@ -90,7 +88,7 @@ Creates a new app in the authenticated organization.
 ```json
 {
   "name": "my-app",
-  "cname": "us-west-2-prod-aws-data",
+  "region": "us-west-2",
   "description": "My Spice app",
   "visibility": "private",
   "tags": {
@@ -101,13 +99,16 @@ Creates a new app in the authenticated organization.
 
 **Request Fields:**
 
-| Field         | Type   | Required | Description                                           |
-| ------------- | ------ | -------- | ----------------------------------------------------- |
-| `name`        | string | **Yes**  | App name (min 4 chars, alphanumeric and hyphens only) |
-| `cname`       | string | **Yes**  | Region identifier (get from `/v1/regions`)            |
-| `description` | string | No       | App description                                       |
-| `visibility`  | string | No       | `public` or `private` (default: `private`)            |
-| `tags`        | object | No       | Key-value tags for organization                       |
+| Field            | Type   | Required | Description                                            |
+| ---------------- | ------ | -------- | ------------------------------------------------------ |
+| `name`           | string | **Yes**  | App name (min 4 chars, alphanumeric and hyphens only)  |
+| `region`         | string | **Yes**  | AWS region code (get from `/v1/regions`)               |
+| `description`    | string | No       | App description                                        |
+| `visibility`     | string | No       | `public` or `private` (default: `private`)             |
+| `tags`           | object | No       | Key-value tags for organization                        |
+| `update_channel` | string | No       | `stable` (default), `preview`, or `nightly`            |
+| `resources`      | object | No       | CPU/memory resource requests                           |
+| `executor`       | object | No       | Executor configuration                                 |
 
 ### Response
 
@@ -120,8 +121,8 @@ Creates a new app in the authenticated organization.
   "description": "My Spice app",
   "visibility": "private",
   "created_at": "2024-01-15T10:00:00.000Z",
+  "cname": "us-west-2-prod-aws-data",
   "production_branch": null,
-  "api_key": "abc123...",
   "tags": {
     "environment": "production"
   },
@@ -148,24 +149,20 @@ Creates a new app in the authenticated organization.
 | `description`       | string \| null | App description                             |
 | `visibility`        | string         | `public` or `private`                       |
 | `created_at`        | string         | ISO 8601 timestamp                          |
+| `cname`             | string         | Region identifier                           |
 | `production_branch` | string \| null | Git branch for production deployments       |
-| `api_key`           | string         | Primary API key                             |
 | `tags`              | object \| null | Key-value tags                              |
 | `config`            | object         | App configuration (see Config Object below) |
 
 **Config Object:**
 
-| Field                   | Type           | Description                                            |
-| ----------------------- | -------------- | ------------------------------------------------------ |
-| `spicepod`              | object \| null | Spicepod YAML configuration                            |
-| `registry`              | string         | Container registry (e.g., `ghcr.io`)                   |
-| `image`                 | string \| null | Container image name                                   |
-| `image_tag`             | string \| null | Spice runtime version tag                              |
-| `update_channel`        | string         | `stable`, `nightly`, `internal`, or `internal-sandbox` |
-| `replicas`              | integer        | Number of replicas (1-10)                              |
-| `region`                | string \| null | AWS region code                                        |
-| `node_group`            | string \| null | Kubernetes node group                                  |
-| `storage_claim_size_gb` | number \| null | Persistent volume size                                 |
+| Field             | Type           | Description                                                                  |
+| ----------------- | -------------- | ---------------------------------------------------------------------------- |
+| `spicepod`        | object \| null | Spicepod YAML configuration                                                  |
+| `image_tag`       | string \| null | Spice runtime version tag                                                    |
+| `update_channel`  | string         | `stable`, `nightly`, `internal`, or `internal-sandbox`                       |
+| `replicas`        | integer        | Number of replicas (1-10)                                                    |
+| `storage_size_gb` | number \| null | Persistent volume size in GB (`storage_claim_size_gb` is deprecated)         |
 {% endtab %}
 
 {% tab title="400: Bad Request" %}
@@ -208,7 +205,7 @@ curl -X POST https://api.spice.ai/v1/apps \
   -H "Content-Type: application/json" \
   -d '{
     "name": "my-app",
-    "cname": "us-west-2-prod-aws-data",
+    "region": "us-west-2",
     "description": "My production app",
     "visibility": "private",
     "tags": {
@@ -231,7 +228,7 @@ response = requests.post(
     },
     json={
         "name": "my-app",
-        "cname": "us-west-2-prod-aws-data",
+        "region": "us-west-2",
         "description": "My production app"
     }
 )
@@ -251,7 +248,7 @@ const response = await fetch('https://api.spice.ai/v1/apps', {
   },
   body: JSON.stringify({
     name: 'my-app',
-    cname: 'us-west-2-prod-aws-data',
+    region: 'us-west-2',
     description: 'My production app'
   })
 });
@@ -310,12 +307,42 @@ Returns details for a specific app, including its configuration.
     "image_tag": "v0.17.0",
     "update_channel": "stable",
     "replicas": 2,
-    "region": "us-east-2",
+    "region": "us-west-2",
     "node_group": null,
-    "storage_claim_size_gb": 10
+    "storage_size_gb": 10
   }
 }
 ```
+
+**Response Fields:**
+
+| Field               | Type           | Description                                  |
+| ------------------- | -------------- | -------------------------------------------- |
+| `id`                | integer        | Unique app identifier                        |
+| `name`              | string         | App name                                     |
+| `description`       | string \| null | App description                              |
+| `visibility`        | string         | `public` or `private`                        |
+| `created_at`        | string         | ISO 8601 timestamp                           |
+| `production_branch` | string \| null | Git branch for production deployments        |
+| `api_key`           | string \| null | Primary API key (for runtime authentication) |
+| `tags`              | object \| null | Key-value tags                               |
+| `config`            | object         | App configuration (see Config Object below)  |
+
+**Config Object:**
+
+| Field             | Type           | Description                                                          |
+| ----------------- | -------------- | -------------------------------------------------------------------- |
+| `spicepod`        | object \| null | Spicepod YAML configuration                                          |
+| `registry`        | string         | Container registry (e.g., `ghcr.io`)                                 |
+| `image`           | string \| null | Container image name                                                 |
+| `image_tag`       | string \| null | Spice runtime version tag                                            |
+| `update_channel`  | string         | `stable`, `nightly`, `internal`, or `internal-sandbox`               |
+| `replicas`        | integer        | Number of replicas (1-10)                                            |
+| `resources`       | object \| null | CPU/memory resource requests                                         |
+| `executor`        | object \| null | Executor configuration                                               |
+| `region`          | string \| null | AWS region code                                                      |
+| `node_group`      | string \| null | Kubernetes node group                                                |
+| `storage_size_gb` | number \| null | Persistent volume size in GB (`storage_claim_size_gb` is deprecated) |
 {% endtab %}
 
 {% tab title="404: Not Found" %}
@@ -367,27 +394,29 @@ Updates an app's metadata and configuration. All fields are optional.
   "image_tag": "v0.17.1",
   "replicas": 3,
   "region": "us-west-2",
-  "storage_claim_size_gb": 20
+  "storage_size_gb": 20
 }
 ```
 
 **Request Fields:**
 
-| Field                   | Type             | Description                                            |
-| ----------------------- | ---------------- | ------------------------------------------------------ |
-| `description`           | string           | App description                                        |
-| `visibility`            | string           | `public` or `private`                                  |
-| `production_branch`     | string           | Git branch for production                              |
-| `tags`                  | object           | Key-value tags                                         |
-| `spicepod`              | string \| object | Spicepod YAML string or JSON object                    |
-| `image_tag`             | string           | Spice runtime version                                  |
-| `image`                 | string           | Container image name                                   |
-| `registry`              | string           | Container registry                                     |
-| `update_channel`        | string           | `stable`, `nightly`, `internal`, or `internal-sandbox` |
-| `replicas`              | integer          | Number of replicas (1-10)                              |
-| `region`                | string           | AWS region code                                        |
-| `node_group`            | string           | Kubernetes node group                                  |
-| `storage_claim_size_gb` | number           | Persistent volume size                                 |
+| Field             | Type             | Description                                            |
+| ----------------- | ---------------- | ------------------------------------------------------ |
+| `description`     | string           | App description                                        |
+| `visibility`      | string           | `public` or `private`                                  |
+| `production_branch` | string         | Git branch for production                              |
+| `tags`            | object           | Key-value tags                                         |
+| `spicepod`        | string \| object | Spicepod YAML string or JSON object                    |
+| `image_tag`       | string           | Spice runtime version                                  |
+| `image`           | string           | Container image name                                   |
+| `registry`        | string           | Container registry                                     |
+| `update_channel`  | string           | `stable` (default), `preview`, or `nightly`            |
+| `replicas`        | integer          | Number of replicas (1-10)                              |
+| `region`          | string           | AWS region code                                        |
+| `node_group`      | string           | Kubernetes node group                                  |
+| `resources`       | object           | CPU/memory resource requests                           |
+| `executor`        | object           | Executor configuration                                 |
+| `storage_size_gb` | number           | Persistent volume size in GB                           |
 
 ### Response
 
@@ -417,12 +446,44 @@ Updates an app's metadata and configuration. All fields are optional.
     "image_tag": "v0.17.1",
     "update_channel": "stable",
     "replicas": 3,
+    "resources": null,
+    "executor": null,
     "region": "us-west-2",
     "node_group": null,
-    "storage_claim_size_gb": 20
+    "storage_size_gb": 20
   }
 }
 ```
+
+**Response Fields:**
+
+| Field               | Type           | Description                                  |
+| ------------------- | -------------- | -------------------------------------------- |
+| `id`                | integer        | Unique app identifier                        |
+| `name`              | string         | App name                                     |
+| `description`       | string \| null | App description                              |
+| `visibility`        | string         | `public` or `private`                        |
+| `created_at`        | string         | ISO 8601 timestamp                           |
+| `production_branch` | string \| null | Git branch for production deployments        |
+| `api_key`           | string \| null | Primary API key (for runtime authentication) |
+| `tags`              | object \| null | Key-value tags                               |
+| `config`            | object         | App configuration (see Config Object below)  |
+
+**Config Object:**
+
+| Field             | Type           | Description                                                          |
+| ----------------- | -------------- | -------------------------------------------------------------------- |
+| `spicepod`        | object \| null | Spicepod YAML configuration                                          |
+| `registry`        | string         | Container registry (e.g., `ghcr.io`)                                 |
+| `image`           | string \| null | Container image name                                                 |
+| `image_tag`       | string \| null | Spice runtime version tag                                            |
+| `update_channel`  | string           | `stable` (default), `preview`, or `nightly`            |
+| `replicas`        | integer        | Number of replicas (1-10)                                            |
+| `resources`       | object \| null | CPU/memory resource requests                                         |
+| `executor`        | object \| null | Executor configuration                                               |
+| `region`          | string \| null | AWS region code                                                      |
+| `node_group`      | string \| null | Kubernetes node group                                                |
+| `storage_size_gb` | number \| null | Persistent volume size in GB (`storage_claim_size_gb` is deprecated) |
 {% endtab %}
 
 {% tab title="400: Bad Request" %}
@@ -575,7 +636,7 @@ Use the `spiceai_app` resource to manage apps. See [Terraform Provider](terrafor
 ```hcl
 resource "spiceai_app" "example" {
   name       = "my-app"
-  cname      = "us-west-2-prod-aws-data"
+  region     = "us-west-2"
   visibility = "private"
 
   spicepod = <<-YAML

--- a/api/management/apps.md
+++ b/api/management/apps.md
@@ -107,7 +107,6 @@ Creates a new app in the authenticated organization.
 | `visibility`     | string | No       | `public` or `private` (default: `private`)             |
 | `tags`           | object | No       | Key-value tags for organization                        |
 | `update_channel` | string | No       | `stable` (default), `preview`, or `nightly`            |
-| `resources`      | object | No       | CPU/memory resource requests                           |
 | `executor`       | object | No       | Executor configuration                                 |
 
 ### Response
@@ -128,13 +127,10 @@ Creates a new app in the authenticated organization.
   },
   "config": {
     "spicepod": null,
-    "registry": "ghcr.io",
-    "image": null,
     "image_tag": null,
     "update_channel": "stable",
     "replicas": 1,
     "region": null,
-    "node_group": null,
     "storage_claim_size_gb": null
   }
 }
@@ -302,13 +298,10 @@ Returns details for a specific app, including its configuration.
         }
       ]
     },
-    "registry": "ghcr.io",
-    "image": "spiceai/spiceai",
     "image_tag": "v0.17.0",
     "update_channel": "stable",
     "replicas": 2,
     "region": "us-west-2",
-    "node_group": null,
     "storage_size_gb": 10
   }
 }
@@ -333,15 +326,10 @@ Returns details for a specific app, including its configuration.
 | Field             | Type           | Description                                                          |
 | ----------------- | -------------- | -------------------------------------------------------------------- |
 | `spicepod`        | object \| null | Spicepod YAML configuration                                          |
-| `registry`        | string         | Container registry (e.g., `ghcr.io`)                                 |
-| `image`           | string \| null | Container image name                                                 |
 | `image_tag`       | string \| null | Spice runtime version tag                                            |
 | `update_channel`  | string         | `stable`, `nightly`, `internal`, or `internal-sandbox`               |
 | `replicas`        | integer        | Number of replicas (1-10)                                            |
-| `resources`       | object \| null | CPU/memory resource requests                                         |
-| `executor`        | object \| null | Executor configuration                                               |
 | `region`          | string \| null | AWS region code                                                      |
-| `node_group`      | string \| null | Kubernetes node group                                                |
 | `storage_size_gb` | number \| null | Persistent volume size in GB (`storage_claim_size_gb` is deprecated) |
 {% endtab %}
 
@@ -408,14 +396,9 @@ Updates an app's metadata and configuration. All fields are optional.
 | `tags`            | object           | Key-value tags                                         |
 | `spicepod`        | string \| object | Spicepod YAML string or JSON object                    |
 | `image_tag`       | string           | Spice runtime version                                  |
-| `image`           | string           | Container image name                                   |
-| `registry`        | string           | Container registry                                     |
 | `update_channel`  | string           | `stable` (default), `preview`, or `nightly`            |
 | `replicas`        | integer          | Number of replicas (1-10)                              |
 | `region`          | string           | AWS region code                                        |
-| `node_group`      | string           | Kubernetes node group                                  |
-| `resources`       | object           | CPU/memory resource requests                           |
-| `executor`        | object           | Executor configuration                                 |
 | `storage_size_gb` | number           | Persistent volume size in GB                           |
 
 ### Response
@@ -441,15 +424,10 @@ Updates an app's metadata and configuration. All fields are optional.
       "name": "my-app",
       "datasets": []
     },
-    "registry": "ghcr.io",
-    "image": "spiceai/spiceai",
     "image_tag": "v0.17.1",
     "update_channel": "stable",
     "replicas": 3,
-    "resources": null,
-    "executor": null,
     "region": "us-west-2",
-    "node_group": null,
     "storage_size_gb": 20
   }
 }
@@ -474,15 +452,10 @@ Updates an app's metadata and configuration. All fields are optional.
 | Field             | Type           | Description                                                          |
 | ----------------- | -------------- | -------------------------------------------------------------------- |
 | `spicepod`        | object \| null | Spicepod YAML configuration                                          |
-| `registry`        | string         | Container registry (e.g., `ghcr.io`)                                 |
-| `image`           | string \| null | Container image name                                                 |
 | `image_tag`       | string \| null | Spice runtime version tag                                            |
 | `update_channel`  | string           | `stable` (default), `preview`, or `nightly`            |
-| `replicas`        | integer        | Number of replicas (1-10)                                            |
-| `resources`       | object \| null | CPU/memory resource requests                                         |
 | `executor`        | object \| null | Executor configuration                                               |
 | `region`          | string \| null | AWS region code                                                      |
-| `node_group`      | string \| null | Kubernetes node group                                                |
 | `storage_size_gb` | number \| null | Persistent volume size in GB (`storage_claim_size_gb` is deprecated) |
 {% endtab %}
 

--- a/api/management/regions.md
+++ b/api/management/regions.md
@@ -41,16 +41,22 @@ Returns a list of available regions where apps can be deployed.
 }
 ```
 
-**Response Fields:**
+**Response Object:**
+
+| Field     | Type   | Description                      |
+| --------- | ------ | -------------------------------- |
+| `regions` | array  | List of available region objects |
+| `default` | string | The default region identifier    |
+
+**Region Object:**
 
 | Field          | Type   | Description                                   |
 | -------------- | ------ | --------------------------------------------- |
 | `name`         | string | Human-readable region name                    |
 | `region`       | string | Region identifier                             |
-| `cname`        | string | Region identifier used when creating apps     |
+| `cname`        | string | Region CNAME identifier                       |
 | `provider`     | string | Cloud provider (`aws`, `azure`, `teraswitch`) |
 | `providerName` | string | Human-readable provider name                  |
-| `default`      | string | The default region identifier                 |
 {% endtab %}
 
 {% tab title="401: Unauthorized" %}
@@ -133,7 +139,7 @@ console.log('Available regions:', data.regions);
 
 ## Using Regions
 
-When creating an app, use the `cname` field from the regions response:
+When creating an app, use the `region` field from the regions response:
 
 ```bash
 curl -X POST https://api.spice.ai/v1/apps \
@@ -141,7 +147,7 @@ curl -X POST https://api.spice.ai/v1/apps \
   -H "Content-Type: application/json" \
   -d '{
     "name": "my-app",
-    "cname": "us-west-2-prod-aws-data"
+    "region": "us-west-2"
   }'
 ```
 
@@ -154,5 +160,5 @@ Consider these factors when selecting a region:
 - **Availability:** Check region availability for your plan tier
 
 {% hint style="info" %}
-The default region (`us-east-2`) is recommended for most use cases.
-{% endhint %}
+The default region (`us-west-2`) is recommended for most use cases.
+{% endhint %}`


### PR DESCRIPTION
This pull request updates the app management and region API documentation to clarify and simplify the usage of region fields, deprecate or remove outdated fields, and improve consistency across endpoints and examples. The changes also add new configuration options and update field descriptions for better accuracy.

Replaced `cname` with `region` in create app api.

Removed internal fields from requests and responses definitions: `image`, `registry`, `node_group`.

Intentionally removed `executor` and `resources` for now, to not promote this in public API.

Corresponding API change - https://github.com/spicehq/cloud/pull/4367