### PR TITLE
Add metrics API docs and monitoring section

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -78,6 +78,7 @@
   * [Secrets](api/management/secrets.md)
   * [API Keys](api/management/api-keys.md)
   * [Members](api/management/members.md)
+  * [Metrics](api/management/metrics.md)
   * [Container Images](api/management/container-images.md)
   * [Terraform Provider](api/management/terraform.md)
 * [Health API](api/health.md)
@@ -132,6 +133,14 @@
 * [Rust SDK](sdks/rust-sdk/README.md)
 * [Dotnet SDK](sdks/dotnet-sdk.md)
 * [Java SDK](sdks/java-sdk.md)
+
+## Monitoring
+
+* [Monitoring](monitoring/README.md)
+  * [Portal](monitoring/portal.md)
+  * [Grafana & Prometheus](monitoring/grafana.md)
+  * [Datadog](monitoring/datadog.md)
+  * [Zipkin](monitoring/zipkin.md)
 
 ## Integrations
 

--- a/api/management/README.md
+++ b/api/management/README.md
@@ -204,6 +204,7 @@ Official SDKs are available for popular languages:
 - [Secrets](secrets.md) - Manage app secrets
 - [API Keys](api-keys.md) - Manage app API keys
 - [Members](members.md) - Manage organization members
+- [Metrics](metrics.md) - Scrape per-app runtime metrics
 - [Container Images](container-images.md) - List available runtime versions
 
 ## Terraform Provider

--- a/api/management/metrics.md
+++ b/api/management/metrics.md
@@ -1,0 +1,248 @@
+---
+description: Scrape per-app runtime metrics
+icon: chart-line
+---
+
+# Metrics
+
+The metrics endpoint exposes per Spice app instance runtime metrics in Prometheus format. Use this endpoint to scrape metrics and send them to Datadog, Grafana, Prometheus, and OpenTelemetry compatible systems for dashboards and alerting.
+
+{% hint style="info" %}
+**Runtime Endpoint:** The metrics endpoint is served by your Spice runtime instance (e.g. `https://<app-cname>.spiceai.io`), not the Management API (`https://api.spice.ai`). Authenticate with your **app API key**, not a Personal Access Token.
+{% endhint %}
+
+## Get Metrics
+
+<mark style="color:blue;">`GET`</mark> `https://<app-cname>.spiceai.io/v1/metrics`
+
+Returns runtime metrics for the Spice app instance in Prometheus exposition format.
+
+### Headers
+
+| Header      | Type   | Description      |
+| ----------- | ------ | ---------------- |
+| `X-API-Key` | string | Your app API key |
+
+### Response
+
+{% tabs %}
+{% tab title="200: OK" %}
+Returns metrics in Prometheus text exposition format.
+
+```
+# HELP http_requests Number of HTTP requests.
+# TYPE http_requests counter
+http_requests_total{method="GET",path="/v1/sql"} 1024
+
+# HELP query_duration_ms The total amount of time spent planning and executing queries in milliseconds.
+# TYPE query_duration_ms histogram
+query_duration_ms_bucket{le="10"} 50
+query_duration_ms_bucket{le="100"} 200
+...
+```
+{% endtab %}
+
+{% tab title="401: Unauthorized" %}
+```json
+{
+  "error": "Unauthorized"
+}
+```
+{% endtab %}
+{% endtabs %}
+
+### Example
+
+```bash
+curl https://us-west-2-prod-aws-data.spiceai.io/v1/metrics \
+  -H "X-API-Key: <API_KEY>"
+```
+
+## Monitoring Integrations
+
+The metrics output is compatible with standard monitoring systems. Pre-built dashboards and setup guides are available:
+
+- [Grafana & Prometheus](../../monitoring/grafana.md) - Scrape metrics with Prometheus, visualize in Grafana
+- [Datadog](../../monitoring/datadog.md) - Scrape metrics with the Datadog Agent's OpenMetrics integration
+- **OpenTelemetry** - Use the OTEL Prometheus receiver
+
+{% hint style="warning" %}
+The metrics endpoint provides Spice runtime metrics only. Kubernetes pod-level metrics (CPU, memory, etc.) are not currently included.
+{% endhint %}
+
+## Available Metrics
+
+All metrics include relevant labels (dimensions) for filtering and aggregation.
+
+### Acceleration
+
+| Metric | Type | Description |
+| ------ | ---- | ----------- |
+| `accelerated_ready_state_federated_fallback` | count | Number of times the federated table was queried due to the accelerated table loading the initial data. |
+| `accelerated_zero_results_federated_fallback` | count | Number of times the federated table was queried due to the accelerated table returning zero results. |
+| `dataset_acceleration_ingestion_lag_ms` | gauge | Lag between the current wall-clock time and the maximum time_column value after the refresh operation, in milliseconds. Disabled by default. |
+| `dataset_acceleration_last_refresh_time_ms` | gauge | Unix timestamp in milliseconds when the last refresh completed. Disabled by default. |
+| `dataset_acceleration_max_timestamp_after_refresh_ms` | gauge | Maximum value of the dataset's time_column after the refresh operation, in milliseconds. Disabled by default. |
+| `dataset_acceleration_max_timestamp_before_refresh_ms` | gauge | Maximum value of the dataset's time_column before the refresh operation, in milliseconds. Disabled by default. |
+| `dataset_acceleration_refresh_data_fetches_skipped` | count | Number of refresh data fetches skipped due to unchanged file metadata. |
+| `dataset_acceleration_refresh_duration_ms` | histogram | Duration in milliseconds to load a full or appended refresh data. |
+| `dataset_acceleration_refresh_errors` | count | Number of errors refreshing the dataset. |
+| `dataset_acceleration_refresh_lag_ms` | gauge | Difference between the maximum time_column value after and before the refresh operation, in milliseconds. |
+| `dataset_acceleration_refresh_worker_panics` | count | Number of times a refresh worker panicked while refreshing a dataset. |
+| `dataset_acceleration_snapshot_bootstrap_bytes` | gauge | Number of bytes downloaded when bootstrapping the acceleration from a snapshot. |
+| `dataset_acceleration_snapshot_bootstrap_checksum` | gauge | Checksum of the snapshot downloaded during bootstrap (emitted with `checksum` attribute). |
+| `dataset_acceleration_snapshot_bootstrap_duration_ms` | count | Time in milliseconds taken to download the snapshot used to bootstrap acceleration. |
+| `dataset_acceleration_snapshot_failure_count` | count | Number of failures encountered while writing snapshots. |
+| `dataset_acceleration_snapshot_write_bytes` | gauge | Number of bytes written for the most recent snapshot. |
+| `dataset_acceleration_snapshot_write_checksum` | gauge | Checksum of the most recent snapshot write (emitted with `checksum` attribute). |
+| `dataset_acceleration_snapshot_write_duration_ms` | histogram | Time in milliseconds taken to write the latest snapshot to object storage. |
+| `dataset_acceleration_snapshot_write_timestamp` | gauge | Unix timestamp (seconds) when the most recent snapshot write completed. |
+
+### Datasets
+
+| Metric | Type | Description |
+| ------ | ---- | ----------- |
+| `dataset_active_count` | gauge | Number of currently loaded datasets. |
+| `dataset_load_errors` | count | Number of errors loading the dataset. |
+| `dataset_load_state` | gauge | Status of the dataset. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown. |
+| `dataset_unavailable_time_ms` | gauge | Time dataset went offline in milliseconds. |
+
+### Catalogs
+
+| Metric | Type | Description |
+| ------ | ---- | ----------- |
+| `catalog_load_errors` | count | Number of errors loading the catalog provider. |
+| `catalog_load_state` | gauge | Status of the catalog provider. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown. |
+
+### Queries
+
+| Metric | Type | Description |
+| ------ | ---- | ----------- |
+| `query_active_count` | histogram | Number of concurrent top-level queries actively being processed. Includes the `protocol` dimension (`http`, `flight`, `flightsql`, `internal`). |
+| `query_duration_ms` | histogram | The total amount of time spent planning and executing queries in milliseconds. |
+| `query_execution_duration_ms` | histogram | The total amount of time spent only executing queries (0 for cached queries). |
+| `query_executions` | count | Number of query executions. |
+| `query_failures` | count | Number of query failures. |
+| `query_processed_bytes` | count | Number of bytes processed by the runtime. |
+| `query_produced_spills` | count | Number of spills produced by the query. |
+| `query_returned_bytes` | count | Number of bytes returned to query clients. |
+| `query_returned_rows` | histogram | Number of rows returned to query clients. |
+| `query_spilled_bytes` | count | Number of spilled bytes produced by the query. |
+| `query_spilled_rows` | count | Number of spilled rows produced by the query. |
+
+### HTTP & Flight
+
+| Metric | Type | Description |
+| ------ | ---- | ----------- |
+| `http_requests` | count | Number of HTTP requests. |
+| `http_requests_duration_ms` | histogram | Measures the duration of HTTP requests in milliseconds. |
+| `flight_requests` | count | Total number of Flight requests. |
+| `flight_request_duration_ms` | histogram | Measures the duration of Flight requests in milliseconds. |
+| `flight_do_exchange_data_updates_sent` | count | Number of data updates sent via DoExchange. |
+
+### AI / LLM
+
+| Metric | Type | Description |
+| ------ | ---- | ----------- |
+| `ai_inferences_with_spice_count` | count | AI Inferences with Spice count. |
+| `llm_requests` | count | Number of LLM requests. |
+| `llm_failures` | count | Number of LLM failures. |
+| `llm_internal_request_duration_ms` | histogram | The duration of running an LLM request internally. |
+| `llm_load_state` | gauge | Status of the LLM model. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown. |
+
+### Models
+
+| Metric | Type | Description |
+| ------ | ---- | ----------- |
+| `model_active_count` | gauge | Number of currently loaded models. |
+| `model_load_duration_ms` | histogram | Duration in milliseconds to load the model. |
+| `model_load_errors` | count | Number of errors loading the model. |
+| `model_load_state` | gauge | Status of the model. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown. |
+
+### Embeddings
+
+| Metric | Type | Description |
+| ------ | ---- | ----------- |
+| `embeddings_active_count` | gauge | Number of currently loaded embeddings. |
+| `embeddings_requests` | count | Number of embedding requests. |
+| `embeddings_failures` | count | Number of embedding failures. |
+| `embeddings_internal_request_duration_ms` | histogram | The duration of running an embedding(s) internally. |
+| `embeddings_load_errors` | count | Number of errors loading the embedding. |
+| `embeddings_load_state` | gauge | Status of the embedding. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown. |
+
+### Embeddings Cache
+
+| Metric | Type | Description |
+| ------ | ---- | ----------- |
+| `embeddings_cache_hits` | count | Cache hit count. |
+| `embeddings_cache_misses` | count | Cache miss count. |
+| `embeddings_cache_requests` | count | Number of requests to get a key from the cache. |
+| `embeddings_cache_evictions` | count | Number of cache evictions. |
+| `embeddings_cache_hit_ratio` | gauge | Cache hit ratio (hits / total requests). |
+| `embeddings_cache_items_count` | gauge | Number of items currently in the cache. |
+| `embeddings_cache_size_bytes` | gauge | Size of the cache in bytes. |
+| `embeddings_cache_max_size_bytes` | gauge | Maximum allowed size of the cache in bytes. |
+| `embeddings_cache_stale_swr_count` | count | Number of stale-while-revalidate background refreshes skipped due to existing in-flight revalidation. |
+| `embeddings_cache_swr_background_query_count` | count | Number of background queries triggered for stale-while-revalidate cache refreshes. |
+
+### Results Cache
+
+| Metric | Type | Description |
+| ------ | ---- | ----------- |
+| `results_cache_hits` | count | Cache hit count. |
+| `results_cache_misses` | count | Cache miss count. |
+| `results_cache_requests` | count | Number of requests to get a key from the cache. |
+| `results_cache_evictions` | count | Number of cache evictions. |
+| `results_cache_hit_ratio` | gauge | Cache hit ratio (hits / total requests). |
+| `results_cache_items_count` | gauge | Number of items currently in the cache. |
+| `results_cache_size_bytes` | gauge | Size of the cache in bytes. |
+| `results_cache_max_size_bytes` | gauge | Maximum allowed size of the cache in bytes. |
+| `results_cache_stale_swr_count` | count | Number of stale-while-revalidate background refreshes skipped due to existing in-flight revalidation. |
+| `results_cache_swr_background_query_count` | count | Number of background queries triggered for stale-while-revalidate cache refreshes. |
+
+### Search Results Cache
+
+| Metric | Type | Description |
+| ------ | ---- | ----------- |
+| `search_results_cache_hits` | count | Search cache hit count. |
+| `search_results_cache_misses` | count | Cache miss count. |
+| `search_results_cache_requests` | count | Number of requests to get a key from the search cache. |
+| `search_results_cache_evictions` | count | Number of cache evictions. |
+| `search_results_cache_hit_ratio` | gauge | Cache hit ratio (hits / total requests). |
+| `search_results_cache_items_count` | gauge | Number of items currently in the search cache. |
+| `search_results_cache_size_bytes` | gauge | Size of the search cache in bytes. |
+| `search_results_cache_max_size_bytes` | gauge | Maximum allowed size of the search cache in bytes. |
+| `search_results_cache_stale_swr_count` | count | Number of stale-while-revalidate background refreshes skipped due to existing in-flight revalidation. |
+| `search_results_cache_swr_background_query_count` | count | Number of background queries triggered for stale-while-revalidate cache refreshes. |
+
+### Tools & Views
+
+| Metric | Type | Description |
+| ------ | ---- | ----------- |
+| `tool_active_count` | gauge | Number of currently loaded LLM tools. |
+| `tool_load_errors` | count | Number of errors loading the LLM tool. |
+| `tool_load_state` | gauge | Status of the LLM tools. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown. |
+| `view_load_errors` | count | Number of errors loading the view. |
+| `view_load_state` | gauge | Status of the views. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown. |
+
+### Runtime
+
+| Metric | Type | Description |
+| ------ | ---- | ----------- |
+| `component_metric_registered_count` | gauge | Number of currently registered component metrics. |
+| `runtime_http_server_started` | count | Indicates the runtime HTTP server has started. |
+| `runtime_flight_server_started` | count | Indicates the runtime Flight server has started. |
+| `secrets_store_load_duration_ms` | histogram | Duration in milliseconds to load the secret stores. |
+| `worker_active_count` | gauge | Number of currently loaded workers. |
+| `workers_load_duration_ms` | histogram | Duration in milliseconds to load the worker. |
+
+{% hint style="info" %}
+In addition to these core metrics, individual components can expose their own metrics. For example, the MySQL data connector exposes connection pool metrics. See the [Spice OSS Observability docs](https://spiceai.org/docs/features/observability) for more details.
+{% endhint %}
+
+See also:
+
+- [Monitoring](../../monitoring/README.md) - Set up dashboards with Grafana, Prometheus, or Datadog
+- [Apps API](apps.md) - Manage your apps
+- [API Keys](api-keys.md) - Manage app API keys
+- [Observability](../../features/observability/README.md) - Observability features in the portal

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,26 @@
+---
+description: Monitor Spice Cloud apps with Prometheus, Grafana, Datadog, and OpenTelemetry
+icon: chart-mixed
+---
+
+# Monitoring
+
+Spice Cloud exposes a [Prometheus-compatible metrics endpoint](../api/management/metrics.md) (`/v1/metrics`) on each app instance. Use it to scrape runtime metrics and build dashboards and alerts in your monitoring platform of choice.
+
+```bash
+curl https://<app-cname>.spiceai.io/v1/metrics \
+  -H "X-API-Key: <API_KEY>"
+```
+
+Pre-built dashboards and setup guides are available:
+
+- [Portal](portal.md) - Built-in monitoring dashboard in the Spice.ai Cloud portal
+- [Grafana & Prometheus](grafana.md) - Scrape metrics with Prometheus, visualize in Grafana
+- [Datadog](datadog.md) - Scrape metrics with the Datadog Agent's OpenMetrics integration
+- [Zipkin](zipkin.md) - Distributed tracing with Zipkin
+
+For the full list of available metrics, see the [Metrics API reference](../api/management/metrics.md#available-metrics).
+
+{% hint style="warning" %}
+The metrics endpoint provides Spice runtime metrics only. Kubernetes pod-level metrics (CPU, memory, etc.) are not currently included.
+{% endhint %}

--- a/monitoring/datadog.md
+++ b/monitoring/datadog.md
@@ -1,0 +1,45 @@
+---
+description: Monitor Spice Cloud with Datadog
+icon: dog
+---
+
+# Datadog
+
+Spice Cloud can be monitored with Datadog using the [Metrics endpoint](../api/management/metrics.md) and a pre-built dashboard available in the [Spice repository](https://github.com/spiceai/spiceai/blob/trunk/monitoring/datadog-dashboard.json).
+
+## Datadog Agent Configuration
+
+**Prerequisite:** Datadog Agent version 6.5.0 or later is [installed](https://docs.datadoghq.com/agent/).
+
+Configure the Datadog Agent to scrape your Spice Cloud metrics endpoint. Edit the `openmetrics.d/conf.yaml` file in the `conf.d/` folder at the root of your Agent's configuration directory:
+
+```yaml
+init_config:
+
+instances:
+  - prometheus_url: https://<app-cname>.spiceai.io/v1/metrics
+    headers:
+      X-API-Key: <API_KEY>
+    namespace: spice
+    metrics:
+      - '*'
+```
+
+Replace `<app-cname>` with your app's CNAME (e.g. `us-west-2-prod-aws-data`) and `<API_KEY>` with your [app API key](../portal/apps/api-keys.md).
+
+Restart the Agent to start collecting Spice metrics. Refer to [Prometheus and OpenMetrics metrics collection from a host](https://docs.datadoghq.com/integrations/guide/prometheus-host-collection/) for all available configuration options and supported parameters.
+
+Open the Datadog **Metrics Explorer** and type `spice` to confirm Spice telemetry is successfully collected.
+
+## Import Datadog Dashboard
+
+1. In Datadog, create a **New Dashboard**
+2. Click **Import dashboard JSON**
+3. Upload the [`datadog-dashboard.json`](https://raw.githubusercontent.com/spiceai/spiceai/trunk/monitoring/datadog-dashboard.json) file
+
+The dashboard provides panels for system health, query performance, data acceleration, caching, AI/ML operations, and Flight protocol metrics.
+
+See also:
+
+- [Metrics API](../api/management/metrics.md) - Endpoint reference and full list of available metrics
+- [Grafana & Prometheus](grafana.md) - Alternative monitoring with Grafana

--- a/monitoring/grafana.md
+++ b/monitoring/grafana.md
@@ -1,0 +1,45 @@
+---
+description: Monitor Spice Cloud with Grafana and Prometheus
+icon: chart-line
+---
+
+# Grafana & Prometheus
+
+Spice Cloud can be monitored with Grafana using the [Metrics endpoint](../api/management/metrics.md) and a pre-built dashboard available in the [Spice repository](https://github.com/spiceai/spiceai/blob/trunk/monitoring/grafana-dashboard.json).
+
+## Prometheus Configuration
+
+Configure a Prometheus instance to scrape metrics from your Spice Cloud app:
+
+```yaml
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: spiceai
+    scheme: https
+    metrics_path: /v1/metrics
+    static_configs:
+      - targets: ['<app-cname>.spiceai.io']
+    headers:
+      X-API-Key: <API_KEY>
+```
+
+Replace `<app-cname>` with your app's CNAME (e.g. `us-west-2-prod-aws-data`) and `<API_KEY>` with your [app API key](../portal/apps/api-keys.md).
+
+## Import Grafana Dashboard
+
+1. Navigate to **Dashboards** in Grafana and click **New** > **Import**
+2. Copy the dashboard JSON from [`monitoring/grafana-dashboard.json`](https://raw.githubusercontent.com/spiceai/spiceai/trunk/monitoring/grafana-dashboard.json) into the import box
+3. Click **Load**
+
+The dashboard provides panels for system health, query performance, data acceleration, caching, AI/ML operations, and Flight protocol metrics.
+
+## Grafana as a Query Tool
+
+In addition to metrics monitoring, Grafana can query Spice Cloud data directly using the FlightSQL or Infinity plugins. See the [Grafana Integration](../integrations/grafana.md) guide for setup instructions.
+
+See also:
+
+- [Metrics API](../api/management/metrics.md) - Endpoint reference and full list of available metrics
+- [Datadog](datadog.md) - Alternative monitoring with Datadog

--- a/monitoring/portal.md
+++ b/monitoring/portal.md
@@ -1,0 +1,44 @@
+---
+description: Monitor Spice Cloud apps from the Spice.ai portal
+icon: browser
+---
+
+# Portal Monitoring
+
+The Spice.ai Cloud portal includes a built-in monitoring dashboard — no external tools or configuration required.
+
+## Monitoring Dashboard
+
+The **Monitoring** tab in your app provides real-time visibility into usage, request performance, and API activity:
+
+- **SQL Queries** — total count, success/failure rate, and average duration
+- **AI Completions** — LLM inference request metrics
+- **Vector Searches** — embedding-based search request metrics
+- **Embedding Calculations** — embedding generation metrics
+- **Dataset Refreshes** — accelerated dataset refresh success and timing
+
+### Accessing the Dashboard
+
+1. Navigate to your Spice app in the [portal](https://spice.ai)
+2. Click the **Monitoring** tab in the app navigation sidebar
+3. Select a time range: **1 hour**, **24 hours**, **7 days**, or **28 days**
+
+Use the metrics dashboard to identify usage trends, detect spikes in query duration, and plan capacity.
+
+## API Request Logs
+
+The request logs provide a detailed record of individual API requests, including status codes, durations, and timestamps.
+
+1. Open the **Monitoring** tab for your app
+2. Click **Logs** to switch from the Metrics view to the Logs view
+3. Select a time range: **past hour**, **8 hours**, **24 hours**, or **up to 3 days**
+
+Use request logs to debug failing queries, identify slow requests, and audit API usage.
+
+For full details, see the [Portal Monitoring](../portal/monitoring-and-request-logs.md) documentation.
+
+See also:
+
+- [Metrics API](../api/management/metrics.md) - Scrape metrics programmatically for external dashboards
+- [Grafana & Prometheus](grafana.md) - Self-hosted monitoring with Grafana
+- [Datadog](datadog.md) - Monitoring with Datadog

--- a/monitoring/zipkin.md
+++ b/monitoring/zipkin.md
@@ -1,0 +1,58 @@
+---
+description: Distributed tracing with Zipkin
+icon: magnifying-glass-chart
+---
+
+# Zipkin
+
+Spice supports distributed tracing by integrating with Zipkin and compatible tracing systems. Traces capture completed tasks — SQL queries, AI chat completions, tool calls, dataset refreshes — recording execution time, inputs, outputs, and errors.
+
+## Configuration
+
+Enable Zipkin tracing by configuring the `runtime.tracing` section in your app's `spicepod.yaml`:
+
+```yaml
+runtime:
+  tracing:
+    zipkin_enabled: true
+    zipkin_endpoint: "http://your_zipkin_host:9411/api/v2/spans"
+```
+
+| Parameter          | Default | Description                                                                 |
+| ------------------ | ------- | --------------------------------------------------------------------------- |
+| `zipkin_enabled`   | `false` | Enables or disables Zipkin trace export.                                    |
+| `zipkin_endpoint`  | —       | Required if enabled. The `/api/v2/spans` endpoint on your Zipkin instance.  |
+
+Trace data will be available in the Zipkin UI at `http://your_zipkin_host:9411`. See the [Zipkin Quickstart](https://zipkin.io/pages/quickstart) to run a test server.
+
+## Trace Information
+
+A trace in Spice represents a completed task. Each trace is a unique span recording execution time, inputs, outputs, and errors.
+
+| Field                  | Description                                           |
+| ---------------------- | ----------------------------------------------------- |
+| `trace_id`             | Unique identifier for the trace                       |
+| `span_id`              | Unique identifier for the span                        |
+| `task`                 | Task type (e.g. `sql_query`, `text_embed`, `health`)  |
+| `start_time`           | When the task started                                 |
+| `end_time`             | When the task completed                               |
+| `execution_duration_ms`| Execution duration in milliseconds                    |
+| `error_message`        | Error details, if the task failed                     |
+
+Example trace data:
+
+```
+trace_id                          | task                | execution_duration_ms | error_message
+----------------------------------|---------------------|-----------------------|------------------------------------------
+687e0970f8c49d19c5a08764ea2d4dc1  | text_embed          | 16132.4               |
+1e881188e5fd252b26adb8a8d838efb8  | sql_query           | 6.1                   |
+701874d7282dd47791e7519b343a9694  | accelerated_refresh | 0.4                   |
+3c75d16b6b4b8da98c551d115e1c049c  | sql_query           | 0.1                   | SQL error: ParserError("Expected:...")
+```
+
+For more details, see [Task History](../features/observability/task-history.md).
+
+See also:
+
+- [Portal Monitoring](portal.md) - Built-in monitoring in the Spice.ai portal
+- [Metrics API](../api/management/metrics.md) - Prometheus-compatible metrics endpoint


### PR DESCRIPTION
## Summary
- Add `/v1/metrics` endpoint documentation to the Management API reference, including authentication, example usage, and the full list of available runtime metrics (scraped from [spiceai.org](https://spiceai.org/docs/features/observability#available-metrics))
- Add a new top-level **Monitoring** section with dedicated pages for Portal, Grafana & Prometheus, Datadog, and Zipkin — with scrape configs, pre-built dashboard import steps, and cross-links

## Test plan
- [ ] Verify all new pages render correctly in GitBook
- [ ] Confirm SUMMARY.md navigation shows the new Monitoring section and Metrics subpage
- [ ] Check all cross-links between monitoring pages, metrics API, and portal docs resolve correctly