### PR TITLE
Document identifier case sensitivity and quoting for data connectors

### DIFF
--- a/building-blocks/data-connectors/README.md
+++ b/building-blocks/data-connectors/README.md
@@ -63,3 +63,59 @@ If a format is a document format, each file will be treated as a document, as pe
 {% hint style="info" %}
 **Note** Document formats in Alpha (e.g. pdf, docx) may not parse all structure or text from the underlying documents correctly.
 {% endhint %}
+
+## Identifier Case Sensitivity and Quoting
+
+Spice follows [PostgreSQL conventions](https://spiceai.org/docs/reference/sql) for identifier handling: **unquoted identifiers are normalized to lowercase**. This applies to both the `from` field in dataset definitions and the `name` field used for SQL queries.
+
+### Quoting in the `from` field
+
+To reference a table or schema with mixed-case or uppercase characters in the `from` field, wrap each case-sensitive part in double quotes:
+
+```yaml
+datasets:
+  # Without quoting — "ActionExecutions" is lowercased to "actionexecutions"
+  - from: postgres:my_schema.ActionExecutions
+    name: action_executions
+
+  # With quoting — case is preserved for the table name
+  - from: postgres:my_schema."ActionExecutions"
+    name: action_executions
+
+  # Quote each part individually as needed
+  - from: postgres:"MySchema"."ActionExecutions"
+    name: action_executions
+```
+
+Each dotted part of the identifier is treated independently — quote only the parts that require case preservation. For example, `postgres:my_schema."ActionExecutions"` preserves the case of `ActionExecutions` while `my_schema` is normalized to lowercase.
+
+This applies to all federated database connectors where the `from` field references a table identifier (e.g. `postgres`, `mysql`, `snowflake`, `databricks`, `clickhouse`, `mssql`, `duckdb`, `dremio`, `flightsql`, `spark`, `mongodb`, `oracle`). Connectors that interpret `from` as a file path (e.g. `s3`, `delta_lake`, `ftp`, `abfs`) do not apply identifier normalization.
+
+### Quoting in the `name` field
+
+The `name` field controls the table name used in Spice SQL queries and follows the same lowercase normalization. To preserve case in the dataset name, wrap the value in double quotes. In YAML, use single quotes around the double-quoted value:
+
+```yaml
+datasets:
+  - from: postgres:my_schema."ActionExecutions"
+    name: '"ActionExecutions"'
+```
+
+```sql
+-- Query using the preserved-case name
+SELECT * FROM "ActionExecutions";
+```
+
+If you don't need to preserve case in queries, a lowercase `name` works without quoting:
+
+```yaml
+datasets:
+  - from: postgres:my_schema."ActionExecutions"
+    name: action_executions
+```
+
+```sql
+SELECT * FROM action_executions;
+```
+
+Dataset `name` quoting works regardless of connector type.

--- a/building-blocks/data-connectors/clickhouse.md
+++ b/building-blocks/data-connectors/clickhouse.md
@@ -20,6 +20,10 @@ The `from` field for the ClickHouse connector takes the form of `from:db.dataset
 
 If `db` is not specified in either the `from` field or the `clickhouse_db` parameter, it will default to the `default` database.
 
+{% hint style="info" %}
+Unquoted identifiers are normalized to lowercase. To reference a table or database with mixed-case characters, wrap each case-sensitive part in double quotes: `clickhouse:my_db."MixedCaseTable"`. See [Identifier Case Sensitivity](README.md#identifier-case-sensitivity-and-quoting).
+{% endhint %}
+
 ### `name`
 
 The dataset name. This will be used as the table name within Spice.

--- a/building-blocks/data-connectors/databricks.md
+++ b/building-blocks/data-connectors/databricks.md
@@ -24,6 +24,10 @@ datasets:
 
 The `from` field for the Databricks connector takes the form `databricks:catalog.schema.table` where `catalog.schema.table` is the fully-qualified path to the table to read from.
 
+{% hint style="info" %}
+Unquoted identifiers are normalized to lowercase. To reference a table, schema, or catalog with mixed-case characters, wrap each case-sensitive part in double quotes: `databricks:my_catalog."MySchema"."MyTable"`. See [Identifier Case Sensitivity](README.md#identifier-case-sensitivity-and-quoting).
+{% endhint %}
+
 ### `name`
 
 The dataset name. This will be used as the table name within Spice.

--- a/building-blocks/data-connectors/dremio.md
+++ b/building-blocks/data-connectors/dremio.md
@@ -23,6 +23,10 @@ This connector enables using Dremio as a data source for federated SQL queries.
 
 The `from` field takes the form `dremio:dataset` where `dataset` is the fully qualified name of the dataset to read from.
 
+{% hint style="info" %}
+Unquoted identifiers are normalized to lowercase. To reference a dataset with mixed-case characters, wrap each case-sensitive part in double quotes: `dremio:my_source."MixedCaseDataset"`. See [Identifier Case Sensitivity](README.md#identifier-case-sensitivity-and-quoting).
+{% endhint %}
+
 {% hint style="warning" %}
 **Limitations**
 

--- a/building-blocks/data-connectors/duckdb.md
+++ b/building-blocks/data-connectors/duckdb.md
@@ -27,6 +27,10 @@ The `from` field supports one of two forms:
 | `duckdb:database.schema.table` | Read data from a table named `database.schema.table` in the DuckDB file                                                                                                                             |
 | `duckdb:*`                     | Read data using any DuckDB function that produces a table. For example one of the [data import](https://duckdb.org/docs/data/overview) functions such as `read_json`, `read_parquet` or `read_csv`. |
 
+{% hint style="info" %}
+Unquoted identifiers are normalized to lowercase. To reference a table or schema with mixed-case characters, wrap each case-sensitive part in double quotes: `duckdb:my_database."MySchema"."MyTable"`. See [Identifier Case Sensitivity](README.md#identifier-case-sensitivity-and-quoting).
+{% endhint %}
+
 ### `name`
 
 The dataset name. This will be used as the table name within Spice.

--- a/building-blocks/data-connectors/flightsql.md
+++ b/building-blocks/data-connectors/flightsql.md
@@ -21,6 +21,10 @@ Connect to any Flight SQL compatible server (e.g. Influx 3.0, CnosDB, other Spic
 
 The `from` field takes the form `flightsql:dataset` where `dataset` is the fully qualified name of the dataset to read from.
 
+{% hint style="info" %}
+Unquoted identifiers are normalized to lowercase. To reference a dataset with mixed-case characters, wrap each case-sensitive part in double quotes: `flightsql:my_catalog."MySchema"."MyTable"`. See [Identifier Case Sensitivity](README.md#identifier-case-sensitivity-and-quoting).
+{% endhint %}
+
 ### `name`
 
 The dataset name. This will be used as the table name within Spice.

--- a/building-blocks/data-connectors/mongodb.md
+++ b/building-blocks/data-connectors/mongodb.md
@@ -28,6 +28,10 @@ datasets:
 
 The `from` field takes the form `mongodb:{table_name}` where `table_name` is the table identifer in the MongoDB server to read from.
 
+{% hint style="info" %}
+Unquoted identifiers are normalized to lowercase. To reference a collection with mixed-case characters, wrap it in double quotes: `mongodb:"MixedCaseCollection"`. See [Identifier Case Sensitivity](README.md#identifier-case-sensitivity-and-quoting).
+{% endhint %}
+
 ```yaml
 datasets:
   - from: mongodb:mytable

--- a/building-blocks/data-connectors/mssql.md
+++ b/building-blocks/data-connectors/mssql.md
@@ -30,6 +30,10 @@ datasets:
 
 The `from` field takes the form `mssql:database.schema.table` where `database.schema.table` is the fully-qualified table name in the SQL server.
 
+{% hint style="info" %}
+Unquoted identifiers are normalized to lowercase. To reference a table, schema, or database with mixed-case characters, wrap each case-sensitive part in double quotes: `mssql:my_database."MySchema"."MyTable"`. See [Identifier Case Sensitivity](README.md#identifier-case-sensitivity-and-quoting).
+{% endhint %}
+
 ### `name`
 
 The dataset name. This will be used as the table name within Spice.

--- a/building-blocks/data-connectors/mysql.md
+++ b/building-blocks/data-connectors/mysql.md
@@ -30,6 +30,10 @@ The `from` field takes the form `mysql:database_name.table_name` where `database
 
 If the `database_name` is omitted in the `from` field, the connector will use the database specified in the `mysql_db` parameter. If the `mysql_db` parameter is not provided, it will default to the user's default database.
 
+{% hint style="info" %}
+Unquoted identifiers are normalized to lowercase. To reference a table or database with mixed-case characters, wrap each case-sensitive part in double quotes: `mysql:my_database."MixedCaseTable"`. See [Identifier Case Sensitivity](README.md#identifier-case-sensitivity-and-quoting).
+{% endhint %}
+
 These two examples are identical:
 
 ```yaml

--- a/building-blocks/data-connectors/postgres.md
+++ b/building-blocks/data-connectors/postgres.md
@@ -35,6 +35,10 @@ datasets:
     params: ...
 ```
 
+{% hint style="info" %}
+Unquoted identifiers are normalized to lowercase. To reference a table or schema with mixed-case characters, wrap each case-sensitive part in double quotes: `postgres:my_schema."MixedCaseTable"`. See [Identifier Case Sensitivity](README.md#identifier-case-sensitivity-and-quoting).
+{% endhint %}
+
 ### `name`
 
 The dataset name. This will be used as the table name within Spice.

--- a/building-blocks/data-connectors/snowflake.md
+++ b/building-blocks/data-connectors/snowflake.md
@@ -16,7 +16,7 @@ datasets:
 ```
 
 {% hint style="info" %}
-**Hint** Unquoted table identifiers should be UPPERCASED in the `from` field. See [Identifier resolution](https://docs.snowflake.com/en/sql-reference/identifiers-syntax#label-identifier-casing).
+Unquoted identifiers are normalized to lowercase by Spice. Snowflake normalizes unquoted identifiers to uppercase, so unquoted identifiers in the `from` field should be UPPERCASED (e.g. `snowflake:MY_DATABASE.MY_SCHEMA.MY_TABLE`). To reference a table created with mixed-case in Snowflake, wrap it in double quotes: `snowflake:MY_DATABASE.MY_SCHEMA."mixedCaseTable"`. See [Snowflake identifier resolution](https://docs.snowflake.com/en/sql-reference/identifiers-syntax#label-identifier-casing) and [Identifier Case Sensitivity](README.md#identifier-case-sensitivity-and-quoting).
 {% endhint %}
 
 ## Configuration

--- a/building-blocks/data-connectors/spark.md
+++ b/building-blocks/data-connectors/spark.md
@@ -14,6 +14,10 @@ datasets:
       spark_remote: sc://my-spark-endpoint
 ```
 
+{% hint style="info" %}
+Unquoted identifiers are normalized to lowercase. To reference a table with mixed-case characters, wrap each case-sensitive part in double quotes: `spark:my_catalog."MySchema"."MyTable"`. See [Identifier Case Sensitivity](README.md#identifier-case-sensitivity-and-quoting).
+{% endhint %}
+
 ## Configuration
 
 * `spark_remote`: A [spark remote](https://spark.apache.org/docs/latest/spark-connect-overview.html#set-sparkremote-environment-variable) connection URI. Refer to [spark connect client connection string](https://github.com/apache/spark/blob/master/connector/connect/docs/client-connection-string.md) for parameters in URI.

--- a/reference/sql-reference.md
+++ b/reference/sql-reference.md
@@ -3,3 +3,19 @@
 The Spice Cloud Platform hosts managed Spice.ai Open Source runtime instances.
 
 See the [Spice.ai Open Source SQL Reference](https://spiceai.org/docs/reference/sql) for a complete guide of supported SQL syntax (PostgreSQL-dialect), data types, functions, and commands.
+
+## Identifier Case Sensitivity
+
+Spice follows PostgreSQL conventions for identifier handling: unquoted identifiers (table and column names) are normalized to **lowercase**. To reference a table or column with uppercase or mixed-case characters, wrap the identifier in double quotes.
+
+```sql
+-- These are equivalent (both reference the lowercase table name)
+SELECT * FROM my_table;
+SELECT * FROM MY_TABLE;
+
+-- Double quotes preserve case
+SELECT * FROM "MyTable";
+SELECT * FROM "MyTable"."MixedCaseColumn";
+```
+
+This behavior also applies to [dataset names](../building-blocks/data-connectors/README.md#identifier-case-sensitivity-and-quoting) configured in the `from` and `name` fields of the spicepod.


### PR DESCRIPTION
## Summary
- Adds a central "Identifier Case Sensitivity and Quoting" section to the [Data Connectors overview](building-blocks/data-connectors/README.md) explaining that Spice follows PostgreSQL conventions (unquoted identifiers → lowercase), with examples for quoting in both `from` and `name` fields
- Adds per-connector quoting hints to all 12 federated database connector pages (postgres, mysql, snowflake, databricks, duckdb, clickhouse, mssql, dremio, flightsql, spark, mongodb, oracle already had it)
- Enhances the existing Snowflake hint to explain the interaction between Spice's lowercase normalization and Snowflake's uppercase normalization
- Adds an "Identifier Case Sensitivity" section to the SQL Reference page

Motivated by a user hitting a BigQuery ADBC 404 because `ActionExecutions` was silently lowercased to `actionexecutions` in the `from` field.

## Test plan
- [ ] Verify GitBook renders the new sections correctly (hint boxes, YAML/SQL code blocks, cross-page links)
- [ ] Confirm links from individual connector pages to `README.md#identifier-case-sensitivity-and-quoting` resolve correctly
- [ ] Confirm link from SQL Reference to the Data Connectors section resolves correctly