### PR TITLE
faq: document incremental ingestion with time_column, overlap, retention, and soft deletes

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -97,6 +97,8 @@ Spice infers the schema for datasets and views at startup and does not apply run
 
 To pick up a new source schema, restart the Spice runtime. On startup, Spice re-infers the schema from the source and the accelerated table is re-initialized with the updated schema.
 
+Automatic runtime schema evolution is on the [Spice v2.1 roadmap](https://github.com/spiceai/spiceai/blob/trunk/docs/ROADMAP.md).
+
 ### What is Data-grounded AI?
 
 Data-grounded AI anchors models in accurate, current, domain-specific data rather than relying solely on pre-trained knowledge. Spice unifies enterprise data across databases, data lakes, and APIs, dynamically incorporating real-world context at inference time. This helps minimize hallucinations, reduce operational risk, and build trust in AI by delivering reliable, relevant outputs.

--- a/faq.md
+++ b/faq.md
@@ -53,12 +53,12 @@ Yes. Spice integrates with BI tools through standard SQL interfaces (ODBC, JDBC,
 
 ### Does Spice support Change Data Capture (CDC)?
 
-Yes. Spice supports CDC in two ways:
+Yes. Spice supports streaming ingestion from several sources:
 
 - **Native PostgreSQL logical replication** (recommended for PostgreSQL sources). Spice connects directly to the source using Postgres' `wal_level=logical` and streams `INSERT`/`UPDATE`/`DELETE` events into the accelerator — no Debezium, no Kafka, no external services. See [PostgreSQL Logical Replication](https://spiceai.org/docs/features/cdc/postgres-replication) in the OSS documentation.
-- **[Debezium](../building-blocks/data-connectors/debezium.md)**, for sources where Debezium + Kafka is already deployed, or for non-PostgreSQL databases (MySQL, SQL Server, etc.).
-
-Both paths are enabled by setting `refresh_mode: changes` on the accelerated dataset.
+- **[DynamoDB Streams](../building-blocks/data-connectors/dynamodb.md)** for Amazon DynamoDB sources — Spice consumes the table's change stream and applies `INSERT`/`UPDATE`/`DELETE` events to the accelerator with `refresh_mode: changes`.
+- **[Apache Kafka](../building-blocks/data-connectors/kafka.md)** for event-streaming topics — Spice consumes records directly with `refresh_mode: append` for real-time, append-only acceleration.
+- **[Debezium](../building-blocks/data-connectors/debezium.md)** (over Kafka) for sources where Debezium is already deployed, or for databases without a native Spice CDC path (MySQL, SQL Server, etc.).
 
 ### How do I keep an accelerated dataset incrementally up-to-date?
 

--- a/faq.md
+++ b/faq.md
@@ -57,39 +57,7 @@ Yes. Spice supports CDC via [Debezium](../building-blocks/data-connectors/debezi
 
 ### How do I keep an accelerated dataset incrementally up-to-date?
 
-For sources that expose a monotonically-increasing version column (e.g. `updated_at`, `lastUpdateTime`), Spice can incrementally ingest only new or modified records using `time_column` together with `refresh_mode: append` and a `refresh_check_interval`. Combined with `retention_period`, old records are automatically evicted so the accelerated replica stays bounded in size.
-
-Behavior:
-
-- **Initial load**: Spice loads all records from the source where `time_column > now() - refresh_data_window`.
-- **Incremental refresh**: On each `refresh_check_interval`, Spice queries the source for records where `time_column` is newer than the most recent value already in the accelerated store, and appends them. If `primary_key` is set, matching rows are upserted instead of duplicated.
-- **Overlap window**: Use `refresh_append_overlap` to widen the incremental query to `time_column > max(time_column) - refresh_append_overlap`. This re-reads a small trailing window on every refresh to tolerate clock skew between the source and the runtime, and to pick up late-arriving writes whose `time_column` is slightly behind the refresh boundary. Combined with `primary_key` upserts, any rows re-read in the overlap are deduplicated rather than duplicated — so no records are lost near the refresh boundary and no duplicates are introduced.
-- **Retention**: On each `retention_check_interval`, rows where `time_column` is older than `retention_period` are removed from the accelerated store, bounding storage and aging out data that is no longer needed.
-
-**Handling deletes.** For sources that do not emit a change feed (e.g. HTTP APIs), the recommended pattern is **soft deletes**: the source marks removed records with a `deleted` flag (and bumps `time_column`). The incremental refresh picks up the tombstone via the normal append path, the upsert replaces the live row with its soft-deleted version, and `retention_period` eventually evicts it from the accelerated store. Queries should filter `WHERE deleted = false` (or use a [view](../building-blocks/views/)) to hide soft-deleted rows. This avoids the cost of periodic full snapshots.
-
-If soft deletes are not available, schedule a periodic `refresh_mode: full` snapshot to reconcile hard deletes by atomically replacing the accelerated contents. For sources that emit a complete change feed (e.g. Debezium, Kafka), use [`refresh_mode: changes`](../building-blocks/data-connectors/debezium.md) instead to propagate inserts, updates, and deletes in real time.
-
-Example — keep the last 90 days of GitHub pull requests, checking for new/updated records every 15 minutes, with a 5-minute overlap to cover clock skew and late arrivals:
-
-```yaml
-datasets:
-  - from: github:github.com/spiceai/spiceai/pulls
-    name: pulls
-    params:
-      github_token: ${secrets:GITHUB_TOKEN}
-      github_query_mode: search
-    time_column: updated_at
-    acceleration:
-      enabled: true
-      refresh_mode: append
-      refresh_check_interval: 15m
-      refresh_append_overlap: 5m
-      refresh_data_window: 90d
-      primary_key: id
-      retention_period: 90d
-      retention_check_interval: 1h
-```
+For sources with a monotonically-increasing version column (e.g. `updated_at`), Spice incrementally ingests new and modified records using `time_column` + `refresh_mode: append`, with `refresh_append_overlap` to tolerate clock skew and `retention_period` to evict old or soft-deleted records. See [Incremental Ingestion](../features/data-acceleration/README.md#incremental-ingestion) for configuration details and examples.
 
 ### Does Spice support schema evolution?
 

--- a/faq.md
+++ b/faq.md
@@ -53,7 +53,12 @@ Yes. Spice integrates with BI tools through standard SQL interfaces (ODBC, JDBC,
 
 ### Does Spice support Change Data Capture (CDC)?
 
-Yes. Spice supports CDC via [Debezium](../building-blocks/data-connectors/debezium.md), enabling real-time data ingestion and materialization from databases such as PostgreSQL and MySQL.
+Yes. Spice supports CDC in two ways:
+
+- **Native PostgreSQL logical replication** (recommended for PostgreSQL sources). Spice connects directly to the source using Postgres' `wal_level=logical` and streams `INSERT`/`UPDATE`/`DELETE` events into the accelerator — no Debezium, no Kafka, no external services. See [PostgreSQL Logical Replication](https://spiceai.org/docs/features/cdc/postgres-replication) in the OSS documentation.
+- **[Debezium](../building-blocks/data-connectors/debezium.md)**, for sources where Debezium + Kafka is already deployed, or for non-PostgreSQL databases (MySQL, SQL Server, etc.).
+
+Both paths are enabled by setting `refresh_mode: changes` on the accelerated dataset.
 
 ### How do I keep an accelerated dataset incrementally up-to-date?
 

--- a/faq.md
+++ b/faq.md
@@ -63,7 +63,7 @@ Yes. Spice integrates with BI tools through standard SQL interfaces (ODBC, JDBC,
 
 Yes. Spice supports streaming ingestion from several sources:
 
-- **Native PostgreSQL logical replication** (recommended for PostgreSQL sources). Spice connects directly to the source using Postgres' `wal_level=logical` and streams `INSERT`/`UPDATE`/`DELETE` events into the accelerator — no Debezium, no Kafka, no external services. See [PostgreSQL Logical Replication](https://spiceai.org/docs/features/cdc/postgres-replication) in the OSS documentation.
+- **Native PostgreSQL logical replication** (recommended for PostgreSQL sources). Spice connects directly to the source using Postgres' `wal_level=logical` and streams `INSERT`/`UPDATE`/`DELETE` events into the accelerator. See [PostgreSQL Logical Replication](https://spiceai.org/docs/features/cdc/postgres-replication) in the OSS documentation.
 - **[DynamoDB Streams](../building-blocks/data-connectors/dynamodb.md)** for Amazon DynamoDB sources — Spice consumes the table's change stream and applies `INSERT`/`UPDATE`/`DELETE` events to the accelerator with `refresh_mode: changes`.
 - **[Apache Kafka](../building-blocks/data-connectors/kafka.md)** for event-streaming topics — Spice consumes records directly with `refresh_mode: append` for real-time, append-only acceleration.
 - **[Debezium](../building-blocks/data-connectors/debezium.md)** (over Kafka) for sources where Debezium is already deployed, or for databases without a native Spice CDC path (MySQL, SQL Server, etc.).

--- a/faq.md
+++ b/faq.md
@@ -5,6 +5,14 @@ icon: circle-question
 
 # FAQ
 
+### What's the difference between Spice.ai OSS, Cloud, and Enterprise?
+
+- **Spice.ai OSS** — the open-source Spice runtime. Self-hosted, free, Apache 2.0.
+- **Spice.ai Cloud** — a managed, multi-tenant hosted service running Spice as a platform with additional building blocks (cloud data warehouse, model training/inference, AI gateway).
+- **Spice.ai Enterprise** — a self-hosted enterprise distribution of Spice with advanced features (HA, RBAC, SSO, governance, premium connectors), enterprise support, and an SLA.
+
+See [Distributions](https://docs.spice.ai/docs/enterprise/getting-started/distributions) for a detailed comparison.
+
 ### What's the difference between the Spice.ai Cloud Platform and Spice.ai OSS?
 
 [**Spice.ai OSS**](https://github.com/spiceai/spiceai) is an open-source project created by the Spice AI team that provides a unified SQL query interface to locally materialize, accelerate, and query data tables sourced from any database, data warehouse, or data lake.

--- a/faq.md
+++ b/faq.md
@@ -55,6 +55,42 @@ Yes. Spice integrates with BI tools through standard SQL interfaces (ODBC, JDBC,
 
 Yes. Spice supports CDC via [Debezium](../building-blocks/data-connectors/debezium.md), enabling real-time data ingestion and materialization from databases such as PostgreSQL and MySQL.
 
+### How do I keep an accelerated dataset incrementally up-to-date?
+
+For sources that expose a monotonically-increasing version column (e.g. `updated_at`, `lastUpdateTime`), Spice can incrementally ingest only new or modified records using `time_column` together with `refresh_mode: append` and a `refresh_check_interval`. Combined with `retention_period`, old records are automatically evicted so the accelerated replica stays bounded in size.
+
+Behavior:
+
+- **Initial load**: Spice loads all records from the source where `time_column > now() - refresh_data_window`.
+- **Incremental refresh**: On each `refresh_check_interval`, Spice queries the source for records where `time_column` is newer than the most recent value already in the accelerated store, and appends them. If `primary_key` is set, matching rows are upserted instead of duplicated.
+- **Overlap window**: Use `refresh_append_overlap` to widen the incremental query to `time_column > max(time_column) - refresh_append_overlap`. This re-reads a small trailing window on every refresh to tolerate clock skew between the source and the runtime, and to pick up late-arriving writes whose `time_column` is slightly behind the refresh boundary. Combined with `primary_key` upserts, any rows re-read in the overlap are deduplicated rather than duplicated — so no records are lost near the refresh boundary and no duplicates are introduced.
+- **Retention**: On each `retention_check_interval`, rows where `time_column` is older than `retention_period` are removed from the accelerated store, bounding storage and aging out data that is no longer needed.
+
+**Handling deletes.** For sources that do not emit a change feed (e.g. HTTP APIs), the recommended pattern is **soft deletes**: the source marks removed records with a `deleted` flag (and bumps `time_column`). The incremental refresh picks up the tombstone via the normal append path, the upsert replaces the live row with its soft-deleted version, and `retention_period` eventually evicts it from the accelerated store. Queries should filter `WHERE deleted = false` (or use a [view](../building-blocks/views/)) to hide soft-deleted rows. This avoids the cost of periodic full snapshots.
+
+If soft deletes are not available, schedule a periodic `refresh_mode: full` snapshot to reconcile hard deletes by atomically replacing the accelerated contents. For sources that emit a complete change feed (e.g. Debezium, Kafka), use [`refresh_mode: changes`](../building-blocks/data-connectors/debezium.md) instead to propagate inserts, updates, and deletes in real time.
+
+Example — keep the last 90 days of GitHub pull requests, checking for new/updated records every 15 minutes, with a 5-minute overlap to cover clock skew and late arrivals:
+
+```yaml
+datasets:
+  - from: github:github.com/spiceai/spiceai/pulls
+    name: pulls
+    params:
+      github_token: ${secrets:GITHUB_TOKEN}
+      github_query_mode: search
+    time_column: updated_at
+    acceleration:
+      enabled: true
+      refresh_mode: append
+      refresh_check_interval: 15m
+      refresh_append_overlap: 5m
+      refresh_data_window: 90d
+      primary_key: id
+      retention_period: 90d
+      retention_check_interval: 1h
+```
+
 ### Does Spice support schema evolution?
 
 Spice infers the schema for datasets and views at startup and does not apply runtime schema changes by default. If the source schema changes while the runtime is running (e.g. columns are added, removed, or their types change), data refreshes will fail with a schema mismatch error rather than silently applying the new schema.

--- a/features/data-acceleration/README.md
+++ b/features/data-acceleration/README.md
@@ -63,7 +63,7 @@ If soft deletes are not available, schedule a periodic `refresh_mode: full` snap
 
 #### Example - Incrementally ingest the last 90 days of GitHub pull requests <a href="#example" id="example"></a>
 
-Checks for new and updated records every 15 minutes, with a 5-minute overlap to cover clock skew and late arrivals:
+Checks for new and updated records every 15 minutes, with a 5-minute overlap to cover clock skew and late arrivals. Rows updated in the source are upserted via `primary_key` + `on_conflict: upsert`, and soft-deleted rows (`deleted_at IS NOT NULL`) are evicted by `retention_sql` in addition to the time-based `retention_period`:
 
 ```yaml
 datasets:
@@ -80,8 +80,12 @@ datasets:
       refresh_append_overlap: 5m
       refresh_data_window: 90d
       primary_key: id
-      retention_period: 90d
+      on_conflict:
+        id: upsert
+      retention_check_enabled: true
       retention_check_interval: 1h
+      retention_period: 90d
+      retention_sql: DELETE FROM pulls WHERE deleted_at IS NOT NULL
 ```
 
 ### Indexes

--- a/features/data-acceleration/README.md
+++ b/features/data-acceleration/README.md
@@ -44,6 +44,46 @@ datasets:
       refresh_check_interval: 10m
 ```
 
+### Incremental Ingestion <a href="#incremental-ingestion" id="incremental-ingestion"></a>
+
+For sources that expose a monotonically-increasing version column (e.g. `updated_at`, `lastUpdateTime`), Spice can incrementally ingest only new or modified records using `time_column` together with `refresh_mode: append` and a `refresh_check_interval`. Combined with `retention_period`, old records are automatically evicted so the accelerated replica stays bounded in size.
+
+**Behavior**
+
+- **Initial load**: Spice loads all records from the source where `time_column > now() - refresh_data_window`.
+- **Incremental refresh**: On each `refresh_check_interval`, Spice queries the source for records where `time_column` is newer than the most recent value already in the accelerated store, and appends them. If `primary_key` is set, matching rows are upserted instead of duplicated.
+- **Overlap window**: Use `refresh_append_overlap` to widen the incremental query to `time_column > max(time_column) - refresh_append_overlap`. This re-reads a small trailing window on every refresh to tolerate clock skew between the source and the runtime, and to pick up late-arriving writes whose `time_column` is slightly behind the refresh boundary. Combined with `primary_key` upserts, any rows re-read in the overlap are deduplicated rather than duplicated — so no records are lost near the refresh boundary and no duplicates are introduced.
+- **Retention**: On each `retention_check_interval`, rows where `time_column` is older than `retention_period` are removed from the accelerated store, bounding storage and aging out data that is no longer needed.
+
+**Handling deletes**
+
+For sources that do not emit a change feed (e.g. HTTP APIs), the recommended pattern is **soft deletes**: the source marks removed records with a `deleted` flag (and bumps `time_column`). The incremental refresh picks up the tombstone via the normal append path, the upsert replaces the live row with its soft-deleted version, and `retention_period` eventually evicts it from the accelerated store. Queries should filter `WHERE deleted = false` (or use a [view](../../building-blocks/views/)) to hide soft-deleted rows. This avoids the cost of periodic full snapshots.
+
+If soft deletes are not available, schedule a periodic `refresh_mode: full` snapshot to reconcile hard deletes by atomically replacing the accelerated contents. For sources that emit a complete change feed (e.g. Debezium, Kafka), use [`refresh_mode: changes`](../../building-blocks/data-connectors/debezium.md) instead to propagate inserts, updates, and deletes in real time.
+
+#### Example - Incrementally ingest the last 90 days of GitHub pull requests <a href="#example" id="example"></a>
+
+Checks for new and updated records every 15 minutes, with a 5-minute overlap to cover clock skew and late arrivals:
+
+```yaml
+datasets:
+  - from: github:github.com/spiceai/spiceai/pulls
+    name: pulls
+    params:
+      github_token: ${secrets:GITHUB_TOKEN}
+      github_query_mode: search
+    time_column: updated_at
+    acceleration:
+      enabled: true
+      refresh_mode: append
+      refresh_check_interval: 15m
+      refresh_append_overlap: 5m
+      refresh_data_window: 90d
+      primary_key: id
+      retention_period: 90d
+      retention_check_interval: 1h
+```
+
 ### Indexes
 
 Database indexes are essential for optimizing query performance. Configure indexes for accelerators via `indexes` field. For detailed configuration, refer to the [index](https://docs.spiceai.org/features/data-acceleration/indexes) documentation.


### PR DESCRIPTION
Adds a new FAQ entry — **How do I keep an accelerated dataset incrementally up-to-date?** — that documents Spice's incremental ingestion model for sources with a monotonically-increasing version column (e.g. `updated_at`, `lastUpdateTime`), including sources that don't expose a change feed (HTTP APIs).

Covers:

- **Initial load** via `refresh_data_window`
- **Incremental refresh** using `time_column` + `refresh_mode: append` + `refresh_check_interval`, with `primary_key` upserts
- **Overlap window** via `refresh_append_overlap` to tolerate source/runtime clock skew and late-arriving writes near the refresh boundary — combined with upserts, no records are lost and no duplicates are introduced
- **Retention** via `retention_period` / `retention_check_interval` to bound storage
- **Handling deletes**: recommends **soft deletes** (a `deleted` flag that bumps `time_column`) as the preferred pattern for HTTP-style connectors — tombstones flow through the upsert path and retention evicts them, avoiding full snapshots. Falls back to periodic `refresh_mode: full` or `refresh_mode: changes` (Debezium / Kafka) where applicable.

Includes a complete worked example using the GitHub connector.