### PR TITLE
Align Enterprise docs with cluster RPC + partitioning model

### DIFF
--- a/building-blocks/data-accelerators/cayenne.md
+++ b/building-blocks/data-accelerators/cayenne.md
@@ -67,7 +67,7 @@ Consider the following limitations when using Cayenne acceleration:
 - **File Mode Only**: Cayenne only supports `mode: file` and does not support in-memory (`mode: memory`) acceleration.
 - **No `on_conflict` Support**: Cayenne does not yet support the [`on_conflict`](../../reference/spicepod/datasets.md#accelerationon_conflict) configuration for handling duplicate keys during data refresh.
 - **Data Cleanup Requires `retention_sql`**: Data deletion and cleanup operations require configuring [`retention_sql`](../../reference/spicepod/datasets.md#accelerationretention_sql) to define retention policies. Manual `DELETE` statements can also be executed directly.
-- **No Snapshot Support**: Cayenne does not yet support [acceleration snapshots](../../features/data-acceleration/snapshots.md) for bootstrapping from object storage.
+- **No Snapshot Support**: Cayenne does not yet support acceleration snapshots in Spice.ai OSS. Snapshots are available in [Spice.ai Enterprise](../../enterprise/features/acceleration-snapshots.md).
 - **Data Types**: Some advanced data types may have limited support. Test your specific schema requirements.
 - **Index Support**: Index capabilities are still being developed. Check release notes for the latest supported features.
 

--- a/enterprise/README.md
+++ b/enterprise/README.md
@@ -12,6 +12,7 @@ Enterprise extends the open-source Spice runtime with:
 - **Multi-node clustering and HA** — Multi-active distributed query with automatic failover, built on Apache Ballista.
 - **Kubernetes Operator** — Automated deployment, scaling, and lifecycle management via `SpicepodSet` and `SpicepodCluster` CRDs.
 - **Acceleration snapshots** — Object-store-backed snapshot, bootstrap, and recovery for accelerated datasets.
+- **Authorization policy** — Cedar-based fine-grained access control over datasets, models, tools, and endpoints.
 - **Enterprise distributions** — NAS (SMB/NFS), CUDA GPU-accelerated, data-only, and ODBC connector builds.
 - **Authentication** — OIDC bearer tokens, API keys, and combined auth with identity SQL functions.
 - **mTLS cluster security** — Auto-provisioned certificates for secure inter-node communication.

--- a/enterprise/README.md
+++ b/enterprise/README.md
@@ -10,6 +10,7 @@ description: Spice.ai Enterprise documentation — self-hosted, production-grade
 Enterprise extends the open-source Spice runtime with:
 
 - **Multi-node clustering and HA** — Multi-active distributed query with automatic failover, built on Apache Ballista.
+- **Distributed accelerations** — Partition-sharded accelerated datasets across executors with write-through semantics. See [Distributed Accelerations](features/distributed-accelerations.md).
 - **Kubernetes Operator** — Automated deployment, scaling, and lifecycle management via `SpicepodSet` and `SpicepodCluster` CRDs.
 - **Acceleration snapshots** — Object-store-backed snapshot, bootstrap, and recovery for accelerated datasets. See [Acceleration Snapshots](features/acceleration-snapshots.md).
 - **Authorization policy** — Cedar-based fine-grained access control over datasets, models, tools, and endpoints.

--- a/enterprise/README.md
+++ b/enterprise/README.md
@@ -11,6 +11,7 @@ Enterprise extends the open-source Spice runtime with:
 
 - **Multi-node clustering and HA** — Multi-active distributed query with automatic failover, built on Apache Ballista.
 - **Kubernetes Operator** — Automated deployment, scaling, and lifecycle management via `SpicepodSet` and `SpicepodCluster` CRDs.
+- **Acceleration snapshots** — Object-store-backed snapshot, bootstrap, and recovery for accelerated datasets.
 - **Enterprise distributions** — NAS (SMB/NFS), CUDA GPU-accelerated, data-only, and ODBC connector builds.
 - **Authentication** — OIDC bearer tokens, API keys, and combined auth with identity SQL functions.
 - **mTLS cluster security** — Auto-provisioned certificates for secure inter-node communication.

--- a/enterprise/README.md
+++ b/enterprise/README.md
@@ -11,7 +11,7 @@ Enterprise extends the open-source Spice runtime with:
 
 - **Multi-node clustering and HA** — Multi-active distributed query with automatic failover, built on Apache Ballista.
 - **Kubernetes Operator** — Automated deployment, scaling, and lifecycle management via `SpicepodSet` and `SpicepodCluster` CRDs.
-- **Acceleration snapshots** — Object-store-backed snapshot, bootstrap, and recovery for accelerated datasets.
+- **Acceleration snapshots** — Object-store-backed snapshot, bootstrap, and recovery for accelerated datasets. See [Acceleration Snapshots](features/acceleration-snapshots.md).
 - **Authorization policy** — Cedar-based fine-grained access control over datasets, models, tools, and endpoints.
 - **Enterprise distributions** — NAS (SMB/NFS), CUDA GPU-accelerated, data-only, and ODBC connector builds.
 - **Authentication** — OIDC bearer tokens, API keys, and combined auth with identity SQL functions.

--- a/enterprise/SUMMARY.md
+++ b/enterprise/SUMMARY.md
@@ -35,5 +35,6 @@
 
 * [Authentication](features/authentication.md)
 * [Authorization Policy](features/policy.md)
+* [Acceleration Snapshots](features/acceleration-snapshots.md)
 * [Distributed Query](features/distributed-query.md)
 * [mTLS Cluster Security](features/mtls.md)

--- a/enterprise/SUMMARY.md
+++ b/enterprise/SUMMARY.md
@@ -34,5 +34,6 @@
 ## Features
 
 * [Authentication](features/authentication.md)
+* [Authorization Policy](features/policy.md)
 * [Distributed Query](features/distributed-query.md)
 * [mTLS Cluster Security](features/mtls.md)

--- a/enterprise/SUMMARY.md
+++ b/enterprise/SUMMARY.md
@@ -36,5 +36,6 @@
 * [Authentication](features/authentication.md)
 * [Authorization Policy](features/policy.md)
 * [Acceleration Snapshots](features/acceleration-snapshots.md)
+* [Distributed Accelerations](features/distributed-accelerations.md)
 * [Distributed Query](features/distributed-query.md)
 * [mTLS Cluster Security](features/mtls.md)

--- a/enterprise/features/acceleration-snapshots.md
+++ b/enterprise/features/acceleration-snapshots.md
@@ -1,0 +1,152 @@
+---
+description: Object-store-backed snapshot, bootstrap, and recovery for accelerated datasets in Spice.ai Enterprise.
+icon: camera
+---
+
+# Acceleration Snapshots
+
+Acceleration snapshots persist accelerated dataset state to an object store so that a Spice runtime can bootstrap a new replica or executor without re-fetching from the federated source. Snapshots dramatically reduce cold-start time, support fast scale-out, and provide a simple disaster-recovery path for accelerated state.
+
+{% hint style="info" %}
+Acceleration snapshots are a **Spice.ai Enterprise** feature. They are not available in Spice.ai OSS.
+{% endhint %}
+
+## How it works
+
+1. The runtime writes the accelerated dataset to an object store (S3-compatible, Azure Blob, GCS, or any [object store with conditional writes](https://spiceai.org/docs/components/data-connectors/s3)).
+2. On startup, an accelerated dataset that opts into snapshots reads the most recent snapshot from the configured location and hydrates its local accelerator before serving queries.
+3. While running, snapshots are produced according to the dataset's configured trigger and creation policy. Older snapshots can be compacted to bound storage cost.
+4. In a [`SpicepodCluster`](../kubernetes/spicepodcluster.md), each executor reads the snapshot for the partitions it owns and writes new snapshots after refreshes complete on the partitions it is responsible for.
+
+| Engine                   | Snapshot support                                   | Notes                                                                                                  |
+| ------------------------ | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| **DuckDB**               | ✓ Bootstrap + create                                | File-mode; snapshot is the DuckDB file uploaded to object storage.                                     |
+| **SQLite**               | ✓ Bootstrap + create                                | File-mode; snapshot is the SQLite file uploaded to object storage.                                     |
+| **Cayenne**              | ✓ Bootstrap + create (recommended for distributed) | Vortex storage with SQLite metadata; integrates natively with `SpicepodCluster` partitioned executors. |
+| **Arrow (in-memory)**    | —                                                  | Re-fetched from source on restart.                                                                     |
+| **Postgres (external)**  | —                                                  | External database is itself the durable store.                                                         |
+
+## Configuration
+
+Snapshots are configured in two places:
+
+1. **Top-level `snapshots`** — declares the snapshot store location, credentials, and global behavior.
+2. **Per-dataset `acceleration.snapshots*`** — opts the dataset into snapshots and chooses behavior, trigger, and compaction.
+
+```yaml
+# Top-level snapshot store configuration
+snapshots:
+  enabled: true                         # default: true
+  location: "s3://my-bucket/spice/snapshots/"
+  bootstrap_on_failure_behavior: warn   # warn | retry | fallback
+  params:
+    region: us-east-1
+    s3_auth: iam_role                   # default for snapshots; override with `key`
+    # s3_key: ${secrets:AWS_ACCESS_KEY_ID}
+    # s3_secret: ${secrets:AWS_SECRET_ACCESS_KEY}
+
+datasets:
+  - from: s3://lake/sales/
+    name: sales
+    acceleration:
+      enabled: true
+      engine: cayenne
+      partition_by:
+        - region: "region"
+      # Per-dataset opt-in
+      snapshots: enabled                  # disabled | enabled | bootstrap_only | create_only
+      snapshots_trigger: refresh_complete # refresh_complete | time_interval | stream_batches
+      snapshots_trigger_threshold: "10m"  # required when trigger is time_interval / stream_batches
+      snapshots_compaction: enabled       # disabled (default) | enabled
+      snapshots_creation_policy: on_change # on_change (default) | always
+      snapshots_reset_expiry_on_load: disabled # disabled (default) | enabled
+```
+
+### Top-level `snapshots`
+
+| Field                            | Type                                | Default     | Description                                                                                                          |
+| -------------------------------- | ----------------------------------- | ----------- | -------------------------------------------------------------------------------------------------------------------- |
+| `enabled`                        | bool                                | `true`      | Global on/off switch. When `false`, no dataset can use snapshots regardless of per-dataset config.                   |
+| `location`                       | string                              | —           | Object-store URL of the snapshot folder (e.g. `s3://bucket/spice/snapshots/`, `abfs://…`, `gs://…`).                |
+| `bootstrap_on_failure_behavior`  | `warn` \| `retry` \| `fallback`     | `warn`      | What to do if snapshot load fails. `warn` continues with empty acceleration; `retry` retries indefinitely; `fallback` tries older snapshots. |
+| `params`                         | object                              | —           | Object-store auth/configuration. For S3, defaults to `s3_auth: iam_role`; explicit keys may be sourced from secrets. |
+
+### Per-dataset `acceleration` snapshot fields
+
+| Field                            | Type                                                                          | Default      | Description                                                                                                  |
+| -------------------------------- | ----------------------------------------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------ |
+| `snapshots`                      | `disabled` \| `enabled` \| `bootstrap_only` \| `create_only`                  | `disabled`   | Per-dataset opt-in. `enabled` does both bootstrap and create. `bootstrap_only` only loads. `create_only` only writes. |
+| `snapshots_trigger`              | `refresh_complete` \| `time_interval` \| `stream_batches`                     | `refresh_complete` | When to attempt to write a snapshot.                                                                  |
+| `snapshots_trigger_threshold`    | duration / count string                                                       | —            | For `time_interval` (e.g. `"10m"`) and `stream_batches` (e.g. `"1000"`) triggers.                            |
+| `snapshots_compaction`           | `disabled` \| `enabled`                                                       | `disabled`   | When `enabled`, older snapshots are compacted/garbage-collected.                                             |
+| `snapshots_creation_policy`      | `on_change` \| `always`                                                       | `on_change`  | `on_change` skips creating a new snapshot when the dataset hasn't changed since the last snapshot.           |
+| `snapshots_reset_expiry_on_load` | `disabled` \| `enabled`                                                       | `disabled`   | When `enabled`, loading a snapshot resets the dataset's expiry/retention clock — useful for cold standby replicas. |
+
+## Behavior modes
+
+| Mode             | Bootstrap from snapshot? | Write new snapshots? | Typical use                                                                                                |
+| ---------------- | :----------------------: | :------------------: | ---------------------------------------------------------------------------------------------------------- |
+| `disabled`       |            —             |          —           | Snapshots off for this dataset (default).                                                                  |
+| `enabled`        |            ✓             |          ✓           | Standard production setting: bootstrap fast, keep the snapshot up to date.                                 |
+| `bootstrap_only` |            ✓             |          —           | Read replicas / scaled-out executors that should hydrate from a shared snapshot but never overwrite it.    |
+| `create_only`    |            —             |          ✓           | A "primary" replica that produces snapshots for other replicas to consume.                                  |
+
+A common topology in `SpicepodCluster` is one `create_only` (or `enabled`) executor per partition writing snapshots, with newly added executors using `bootstrap_only` to come online quickly.
+
+## Triggers
+
+| Trigger             | Threshold required | Description                                                                                                  |
+| ------------------- | :----------------: | ------------------------------------------------------------------------------------------------------------ |
+| `refresh_complete`  |         —          | Default. A snapshot is attempted after each successful dataset refresh.                                       |
+| `time_interval`     |         ✓          | A snapshot is attempted on a timer (`snapshots_trigger_threshold: "10m"`).                                    |
+| `stream_batches`    |         ✓          | For streaming sources, a snapshot is attempted every N consumed batches (`snapshots_trigger_threshold: "1000"`). |
+
+`snapshots_creation_policy: on_change` (default) suppresses snapshots when there is no change to commit; pair it with `time_interval` or `stream_batches` to bound snapshot frequency.
+
+## Failure handling on bootstrap
+
+`bootstrap_on_failure_behavior` controls what happens if the runtime cannot read the most recent snapshot:
+
+- **`warn`** — Log a warning and continue with an empty acceleration. The next refresh will repopulate it from the federated source. Suitable when the source is fast and snapshots are an optimization.
+- **`retry`** — Retry loading the newest snapshot indefinitely. Suitable for replicas that should not serve stale-empty data.
+- **`fallback`** — Try progressively older snapshots until one loads successfully. Suitable for resilience against a corrupt or partially written latest snapshot.
+
+## Distributed clusters
+
+In a [`SpicepodCluster`](../kubernetes/spicepodcluster.md):
+
+- The snapshot location should point to the same object store used for cluster shared state (or a dedicated bucket) so all schedulers and executors share a single view.
+- Each executor writes snapshots only for the partitions it owns; reads target the same partition layout (Hive-style `key1=v1/key2=v2/...`).
+- New executors joining the cluster receive their partition assignments via `AllocateInitialPartitions` (see [Distributed Query](distributed-query.md#how-executors-learn-their-assignments)) and then bootstrap each owned partition from the snapshot store, avoiding a federated re-scan.
+- Setting `snapshots: bootstrap_only` on executors prevents accidental dual-writers when more than one executor temporarily believes it owns a partition during a transition; the scheduler-confirmed owner uses `enabled` or `create_only`.
+
+## Observability
+
+Acceleration snapshots emit Prometheus / OTLP metrics on every node:
+
+| Metric                                                  | Type      | Description                                                                                  |
+| ------------------------------------------------------- | --------- | -------------------------------------------------------------------------------------------- |
+| `dataset_acceleration_snapshot_bootstrap_bytes`         | gauge     | Bytes downloaded when bootstrapping the acceleration from a snapshot.                        |
+| `dataset_acceleration_snapshot_bootstrap_checksum`      | gauge     | Checksum of the snapshot downloaded during bootstrap (emitted with `checksum` attribute).    |
+| `dataset_acceleration_snapshot_bootstrap_duration_ms`   | counter   | Time in ms taken to download the snapshot used to bootstrap acceleration.                    |
+| `dataset_acceleration_snapshot_failure_count`           | counter   | Number of failures encountered while writing snapshots.                                      |
+| `dataset_acceleration_snapshot_write_bytes`             | gauge     | Bytes written for the most recent snapshot.                                                  |
+| `dataset_acceleration_snapshot_write_checksum`          | gauge     | Checksum of the most recent snapshot write (emitted with `checksum` attribute).              |
+| `dataset_acceleration_snapshot_write_duration_ms`       | histogram | Time in ms taken to write the latest snapshot to object storage.                              |
+| `dataset_acceleration_snapshot_write_timestamp`         | gauge     | Unix timestamp (seconds) when the most recent snapshot write completed.                      |
+
+## Production checklist
+
+- [ ] Snapshot bucket has versioning enabled and a lifecycle policy that retains a documented number of snapshot generations.
+- [ ] `bootstrap_on_failure_behavior: fallback` is used on critical datasets that cannot tolerate empty starts.
+- [ ] Object-store credentials use IRSA / workload identity, not long-lived access keys.
+- [ ] An alert is configured on `dataset_acceleration_snapshot_failure_count` greater than zero over a rolling 15-minute window.
+- [ ] An alert is configured on stale `dataset_acceleration_snapshot_write_timestamp` for datasets that should snapshot regularly.
+- [ ] In `SpicepodCluster`, the snapshot bucket is in the same region as the runtime nodes to minimise bootstrap latency.
+
+## See also
+
+- [Distributed Query — Acceleration snapshots (Cayenne)](distributed-query.md#acceleration-snapshots-cayenne)
+- [SpicepodCluster CRD reference](../kubernetes/spicepodcluster.md)
+- [Storage](../production/storage.md)
+- [Observability](../production/observability.md)

--- a/enterprise/features/distributed-accelerations.md
+++ b/enterprise/features/distributed-accelerations.md
@@ -1,0 +1,189 @@
+---
+description: Partition-sharded accelerated datasets across executors with write-through semantics in Spice.ai Enterprise.
+icon: grid-2-plus
+---
+
+# Distributed Accelerations
+
+In a [distributed query cluster](distributed-query.md), Spice.ai Enterprise shards each accelerated dataset and view across executors so that every executor materialises and serves only the partitions it owns. The scheduler holds **no row data**; it presents a logical `UNION ALL` of all executors and routes reads and writes by partition key.
+
+{% hint style="info" %}
+Distributed accelerations are a **Spice.ai Enterprise** feature. They require a `SpicepodCluster` with at least one scheduler and one executor. They are not available in Spice.ai OSS.
+{% endhint %}
+
+## Why partition?
+
+A single-replica accelerated dataset is bounded by the memory and disk of one node. Partitioning the acceleration across many executors:
+
+- Scales accelerated capacity linearly with the number of executors.
+- Localises hot data on NVMe-backed executors and keeps the scheduler stateless.
+- Bounds query fan-out — only executors holding a relevant partition are scanned.
+- Enables independent refresh, snapshot, and recovery per partition.
+
+## Declaring partitions
+
+Every accelerated dataset and view in cluster mode **must** declare at least one partition key via `acceleration.partition_by`. Startup fails otherwise:
+
+> `Accelerated {component_type} '{name}' has no partition keys configured. Add 'partition_by' to its acceleration config to participate in cluster partition assignment.`
+
+```yaml
+datasets:
+  - from: postgres:public.events
+    name: events
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+      partition_by:
+        - "bucket(100, customer_id)"        # static hash bucketing — no source query
+        - { region: "region" }              # named column-value partition
+```
+
+`partition_by` accepts each entry as either:
+
+- A plain expression string (auto-named `expr0`, `expr1`, …), e.g. `"YEAR(created_at)"` or `"bucket(64, user_id)"`.
+- A single-entry mapping `{ name: expression }`, e.g. `{ year: "YEAR(created_at)" }`.
+
+Multiple keys yield the cartesian product of values; each combination is one partition.
+
+### Static vs. dynamic discovery
+
+For each accelerated table, the scheduler discovers the set of partition values exactly once per refresh cycle. There are two paths:
+
+- **Static** — `bucket(N, col)` is recognised at config time and expands to values `0, 1, …, N-1` without contacting the source. `N` must be a positive integer literal up to **1,000,000**.
+- **Dynamic** — Any other expression is resolved by running `SELECT DISTINCT {expressions} FROM {federated_source}` against the source connector, bounded by `runtime.scheduler.partition_discovery_timeout` (default `60s`).
+
+The `bucket(N, col)` UDF is a deterministic, hash-based bucketing function (`ahash` with a fixed seed) and is evaluable both in the scheduler refresh context and on each executor — so the same row always lands on the same bucket.
+
+## Engine support
+
+| Engine                | Cluster partition assignment | `write_mode: write_through` | Notes                                                                                             |
+| --------------------- | :--------------------------: | :-------------------------: | ------------------------------------------------------------------------------------------------- |
+| **Cayenne**           |              ✓               |              ✓              | Required for write-through. Vortex storage with SQLite metadata. Supports [acceleration snapshots](acceleration-snapshots.md). |
+| **DuckDB**            |              ✓               |              —              | Read-only partitioned acceleration.                                                               |
+| **SQLite**            |              ✓               |              —              | Read-only.                                                                                        |
+| **Arrow (in-memory)** |              ✓               |              —              | Read-only. Data is lost on pod restart unless backed by snapshots.                                |
+| **Postgres**          |              ✓               |              —              | Read-only.                                                                                        |
+
+Attempting `write_mode: write_through` with a non-Cayenne engine fails fast at startup with `Write-through acceleration currently requires the Cayenne accelerator`.
+
+## Per-executor sharding
+
+Each partition has a single owning executor (1:1 assignment recorded in `cluster.json`). Consequences:
+
+- Executor-local accelerations only contain rows that match their assigned partition filter expressions — no executor stores the full dataset.
+- Read paths fan out over the executors that own the partitions touched by the query (statically pruned by `partition_by` predicates whenever possible).
+- Write paths route by partition key; the scheduler computes the owning executor and forwards the write.
+
+The scheduler never holds row data; the DataFusion physical optimiser rule `EnsureSupportedFileScan` rejects scheduler plans containing file-scan nodes that cannot be distributed.
+
+## Partition assignment
+
+Partition assignment lives in the shared `cluster.json` document in the cluster object store and is reconciled by the scheduler:
+
+1. **Discover** — Run static or dynamic discovery for every accelerated table.
+2. **Diff** — Compare the discovered set against the current partitions in `cluster.json` to compute new and removed partitions.
+3. **Assign** — Assign new partitions to executors using a soft-balanced fill (newest partitions first). At most `runtime.scheduler.max_partition_assignments_per_interval` are committed per cycle (default `100`); each executor is capped at `runtime.scheduler.max_partitions_per_executor` (default `1000`).
+4. **Notify** — Push `UpdatePartitions` over the cluster `ControlStream` to each receiving executor; the executor materialises the new partition by scanning its assigned filter from the federated source.
+
+```yaml
+runtime:
+  scheduler:
+    state_location: "s3://my-bucket/spice/cluster/"
+    partition_assignment_interval: "30s"
+    max_partition_assignments_per_interval: 100
+    max_partitions_per_executor: 1000
+    partition_discovery_timeout: "60s"
+```
+
+| Field                                     | Default | Description                                                                                |
+| ----------------------------------------- | ------- | ------------------------------------------------------------------------------------------ |
+| `state_location`                          | —       | Object-store URL of the shared cluster state and snapshots root.                            |
+| `partition_assignment_interval`           | `30s`   | Cadence of periodic partition reconciliation across all accelerated tables.                |
+| `max_partition_assignments_per_interval`  | `100`   | Soft cap on assignments committed per cycle (uncapped on on-demand reconciliation).        |
+| `max_partitions_per_executor`             | `1000`  | Soft per-executor partition cap used to spread load.                                       |
+| `partition_discovery_timeout`             | `60s`   | Time budget for `SELECT DISTINCT` partition discovery against the federated source.        |
+
+Two reconciliation paths share this state:
+
+- **Periodic** (`reconcile_all`) — Every `partition_assignment_interval`, with the per-cycle cap applied.
+- **On-demand** (`reconcile_table`) — Triggered before a refresh forwarded over `ControlStream`, uncapped so newly-discovered partitions are not stranded for a refresh that would target them.
+
+Assignments are committed to `cluster.json` first under optimistic concurrency control (OCC), then pushed to executors. Concurrent schedulers are safe: at most one assignment per partition wins.
+
+## Refresh in cluster mode
+
+- The scheduler is the single source of truth for partition ownership; there is no separate refresh leader election.
+- After every source refresh cycle, partition reconciliation re-runs discovery; new partition values are assigned and `UpdatePartitions` is pushed to the receiving executor, which materialises the new partition.
+- The scheduler can also explicitly issue `RefreshDataset` over the `ControlStream` to trigger a refresh on a specific executor, which is how API-driven refresh requests are routed in cluster mode.
+
+`refresh_mode: changes` (CDC / WAL replication) is fully supported in cluster mode and is the recommended setting for write-through accelerations to keep accelerator state close to the source.
+
+## Write paths
+
+```yaml
+acceleration:
+  enabled: true
+  engine: cayenne
+  write_mode: write_through    # write_through (default) | write_back
+```
+
+| Mode               | Semantics                                                                                                                                                                |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **`write_through`** (default) | Writes commit synchronously to the federated source. Acceleration state catches up via the configured refresh mechanism. **Cluster mode supports `write_through` only on Cayenne.** |
+| **`write_back`**   | Writes commit to the local accelerator first; the source is updated asynchronously. Requires `replication.enabled: true`. Cluster `write_back` is a future extension.    |
+
+In cluster mode, the scheduler computes the owning executor for each row from `partition_by`, splits the incoming Arrow Flight stream into per-executor batches, and forwards each batch to its executor with the same `partition_by` filters applied.
+
+## Acceleration snapshots
+
+Cayenne integrates with [Acceleration Snapshots](acceleration-snapshots.md) so that a newly added executor can hydrate its assigned partitions from object storage instead of re-scanning the federated source:
+
+```yaml
+acceleration:
+  engine: cayenne
+  snapshots: enabled                   # disabled | enabled | bootstrap_only | create_only
+  snapshots_trigger: refresh_complete  # refresh_complete | time_interval | stream_batches
+  snapshots_compaction: enabled
+  snapshots_creation_policy: on_change # on_change | always
+```
+
+Recommended cluster pattern: set `snapshots: enabled` on owning executors (writes the canonical snapshot for their partitions) and `bootstrap_only` on read-replica executors so they never overwrite a snapshot they did not produce.
+
+## Sizing
+
+- Provision each executor's local NVMe to hold its assigned partitions plus a shuffle working set (rule of thumb: ~25% of dataset volume).
+- The scheduler does **not** need fast local storage; provision modest CPU / memory and ensure low-latency access to the cluster object store.
+- `max_partitions_per_executor` is a soft target — keep partition counts much smaller than this in steady state to leave headroom for rebalancing.
+- Partition cardinality should comfortably exceed the executor count so that work spreads evenly. With `bucket(N, col)`, `N` is typically `4×–32×` the executor count.
+- See [Storage](../production/storage.md) for instance-type recommendations.
+
+## Observability
+
+Distributed accelerations emit metrics through the cluster meter alongside the standard [acceleration metrics](../../cloud/api/metrics.md):
+
+| Metric                                  | Where      | Description                                                                  |
+| --------------------------------------- | ---------- | ---------------------------------------------------------------------------- |
+| `scheduler_executor_assignments`        | Scheduler  | Counter of partition assignments committed.                                  |
+| `scheduler_active_executors_count`      | Scheduler  | Number of executors currently registered.                                    |
+| `node_status`                           | Both       | Per-node liveness for schedulers and executors.                              |
+| `dataset_acceleration_refresh_*`        | Executor   | Standard acceleration refresh metrics, emitted per partition owner.          |
+| `dataset_acceleration_snapshot_*`       | Executor   | Snapshot bootstrap / write metrics. See [Acceleration Snapshots](acceleration-snapshots.md). |
+
+## Constraints and edge cases
+
+| Constraint                                                                                                          | Effect                                                                                  |
+| ------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| Every accelerated table and view in cluster mode must declare `partition_by`.                                       | Startup error: `… has no partition keys configured`.                                    |
+| `bucket(N, col)` requires a positive integer literal `N` ≤ `1_000_000`.                                              | Otherwise the scheduler falls through to dynamic discovery, which is unlikely to match.  |
+| `write_mode: write_through` is only supported on Cayenne.                                                            | Startup error on other engines.                                                          |
+| The cluster object store must support conditional writes (S3, GCS, Azure Blob).                                      | Local filesystem is rejected; OCC requires `PutMode::Update`.                            |
+| Partition cardinality below the executor count leaves executors idle; very high cardinality inflates `cluster.json`. | Aim for 4×–32× executors-worth of partitions; tune via `bucket(N, …)` or coarser keys. |
+
+## See also
+
+- [Distributed Query](distributed-query.md) — multi-active execution model and RPC surface.
+- [Acceleration Snapshots](acceleration-snapshots.md) — object-store-backed bootstrap for partitioned executors.
+- [SpicepodCluster CRD](../kubernetes/spicepodcluster.md) — Kubernetes deployment.
+- [Storage](../production/storage.md) — sizing and instance-type guidance.

--- a/enterprise/features/distributed-query.md
+++ b/enterprise/features/distributed-query.md
@@ -249,7 +249,7 @@ Each partition has a single owning executor (1:1 assignment in `cluster.json`). 
 ### Acceleration snapshots (Cayenne)
 
 {% hint style="info" %}
-Acceleration snapshots are a **Spice.ai Enterprise** feature. They are not available in Spice.ai OSS.
+Acceleration snapshots are a **Spice.ai Enterprise** feature. See [Acceleration Snapshots](acceleration-snapshots.md) for the full reference. They are not available in Spice.ai OSS.
 {% endhint %}
 
 Cayenne supports object-store-backed acceleration snapshots that integrate naturally with cluster mode, allowing a newly started executor to bootstrap from the shared object store rather than re-fetching from the federated source:

--- a/enterprise/features/distributed-query.md
+++ b/enterprise/features/distributed-query.md
@@ -1,21 +1,21 @@
 ---
-description: Active-active distributed query with Apache Ballista for multi-node Spice.ai clusters.
+description: Multi-active distributed query with Apache Ballista, partition-aware execution, and distributed accelerations for multi-node Spice.ai clusters.
 icon: diagram-project
 ---
 
 # Distributed Query
 
-Spice.ai Enterprise supports distributed query execution, built on [Apache Ballista](https://github.com/apache/datafusion-ballista), for horizontally scaling SQL query workloads across multiple nodes.
+Spice.ai Enterprise supports distributed query execution, built on [Apache Ballista](https://github.com/apache/datafusion-ballista) and [Apache DataFusion](https://datafusion.apache.org/), for horizontally scaling SQL workloads across multiple nodes. A cluster runs in **multi-active** mode with shared state in an S3-compatible object store, executes queries with **partition-aware** routing across executors, and supports **distributed accelerations** with per-partition data ownership and write-through semantics.
 
 ## Architecture
 
-A distributed query cluster consists of:
+A distributed query cluster is composed of three tiers:
 
-- **Schedulers** — Coordinate query planning, catalog synchronization, and work distribution.
-- **Executors** — Execute query stages, perform shuffles, and return results.
-- **Object store** — S3-compatible storage for shared state and shuffle data.
+- **Schedulers** — Coordinate query planning, partition discovery and assignment, async job submission, and federated `task_history` aggregation.
+- **Executors** — Hold accelerated data for their assigned partitions, execute query stages, perform shuffles, and stream results.
+- **Object store** — S3-compatible storage that holds shared cluster state (`cluster.json`, scheduler heartbeats, async job results, and Cayenne acceleration snapshots).
 
-```
+```text
      ┌──────────────────────────────────────┐
      │           Load Balancer              │
      └──────────────────────────────────────┘
@@ -32,24 +32,67 @@ A distributed query cluster consists of:
 └──────────┘     └──────────┘     └──────────┘
 ```
 
-## Active-Active HA
+Schedulers register themselves and discover peers through the object store. **Executors are shared across all schedulers** — they are not bound to or owned by any single scheduler. On startup, an executor connects to its bootstrap scheduler, fetches the full scheduler membership list, and then opens a Ballista task `poll_loop` plus a persistent bidirectional `ControlStream` to **every** scheduler over the internal gRPC port (`50052`). It refreshes the membership list every 10 s and adds/drops connections as schedulers join or leave. Any scheduler can dispatch tasks to any executor, and an executor's partition assignment is owned by the cluster (persisted in the object store), not by the scheduler that allocated it.
 
-Multiple schedulers can run simultaneously in active-active mode:
+## Multi-Active High Availability
 
-- **Shared state** is maintained in an S3-compatible object store with conditional writes for conflict resolution.
-- **Scheduler discovery** uses shared state registration — no external coordination service required.
-- **Executor discovery** is executor-initiated — executors connect to all known schedulers.
-- **Jobs execute exactly once** across the cluster.
+Multiple schedulers run simultaneously without an external coordinator:
 
-## Deployment
+- **Shared state** — Cluster membership and per-table partition metadata are persisted in `cluster.json` in the configured object store. All mutations use **optimistic concurrency control** (ETag / `If-Match`) with up to 8 retry attempts; the schema is versioned (`CLUSTER_STATE_SCHEMA_VERSION = 1`) and incompatible versions are rejected.
+- **Heartbeats** — Each scheduler writes a small `heartbeats/{scheduler_id}.json` file independent of `cluster.json` to avoid contention. Heartbeats refresh at one third of the configured TTL (default ~10 s for a 30 s TTL).
+- **Discovery** — Every scheduler refreshes its peer map every 5 s by reading `cluster.json` plus live heartbeat files.
+- **Reaper** — Schedulers whose last heartbeat exceeds `ttl_ms + 5 s` clock-skew tolerance are evicted on the next reaper tick (jittered ±20 % around `ttl_ms`).
+- **Takeover safety** — Each scheduler process generates a fresh `instance_id` (UUID) at startup, so a restarted process can safely reclaim its previous `scheduler_id` without colliding with itself.
+- **Executor failover** — Executors maintain a poll loop (Fibonacci backoff, max 5 s) and a `ControlStream` to every scheduler concurrently. If a scheduler dies, the executor's other connections remain live and surviving schedulers continue to drive partition assignment and refresh commands without re-binding the executor.
 
-### Kubernetes (SpicepodCluster)
+The object store backing `state_location` **must** support conditional writes. Native AWS S3, S3-compatible stores with `PutIfNotExists`/`PutIfMatch` semantics, and the `file://` backend (for local development) are supported.
 
-The recommended deployment method is the [SpicepodCluster](../kubernetes/spicepodcluster.md) CRD, which automates cluster topology, mTLS, and lifecycle management.
+## Configuration
 
-### Manual (CLI)
+### Spicepod (`runtime.scheduler`)
 
-For non-Kubernetes deployments, configure roles via CLI arguments:
+The presence of `runtime.scheduler` activates scheduler role on a node. Setting `--scheduler-address` at launch time activates executor role.
+
+```yaml
+runtime:
+  scheduler:
+    state_location: "s3://my-bucket/spice-cluster/"
+    params:
+      region: us-east-1
+      auth: iam_role                         # iam_role (default) | key
+      key: ${secrets:AWS_ACCESS_KEY_ID}
+      secret: ${secrets:AWS_SECRET_ACCESS_KEY}
+    partition_assignment_interval: "30s"
+    max_partition_assignments_per_interval: 100
+    max_partitions_per_executor: 1000
+    partition_discovery_timeout: "60s"
+```
+
+| Field                                    | Default | Description                                                                                                 |
+| ---------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------- |
+| `state_location`                         | —       | Object-store URL for shared cluster state. `s3://`, `file://`, or any object store with conditional writes. |
+| `params`                                 | —       | Object-store auth/configuration. `auth: iam_role` is the default; explicit keys are sourced from secrets.   |
+| `partition_assignment_interval`          | `30s`   | How often the partition discovery + assignment loop runs.                                                   |
+| `max_partition_assignments_per_interval` | `100`   | Cap on partitions assigned per cycle to limit churn during scale events.                                    |
+| `max_partitions_per_executor`            | `1000`  | Soft cap per executor used by the assignment heuristic.                                                     |
+| `partition_discovery_timeout`            | `60s`   | Maximum time to spend discovering partition values from the federated source per cycle.                     |
+
+### CLI flags
+
+The same `spiced` binary runs as scheduler or executor; the role is selected by flag combination.
+
+| Flag                              | Default             | Description                                                                              |
+| --------------------------------- | ------------------- | ---------------------------------------------------------------------------------------- |
+| `--role`                          | inferred            | `scheduler` or `executor`. Inferred as `executor` when `--scheduler-address` is set.     |
+| `--node-bind-address`             | `0.0.0.0:50052`     | Internal gRPC bind address for both roles.                                               |
+| `--node-advertise-address`        | required            | Hostname/IP this node advertises to peers. Forms `scheduler_id` as `{advertise}:{port}`. |
+| `--scheduler-address`             | required (executor) | URL of the scheduler's internal gRPC service. Scheme inferred from TLS configuration.    |
+| `--node-mtls-ca-certificate-file` | —                   | PEM CA used to verify peer mTLS certificates.                                            |
+| `--node-mtls-certificate-file`    | —                   | PEM server + client certificate for this node.                                           |
+| `--node-mtls-key-file`            | —                   | Private key for the mTLS certificate.                                                    |
+| `--allow-insecure-connections`    | `false`             | Disable mTLS. **Development / test only.**                                               |
+
+### Manual launch (non-Kubernetes)
 
 ```bash
 # Scheduler
@@ -68,33 +111,241 @@ spiced --role executor \
   --node-advertise-address executor1.cluster.local
 ```
 
-## Catalog and UDF Synchronization
+### Kubernetes (recommended)
 
-In a distributed cluster, executors automatically synchronize catalogs and UDFs from the scheduler:
+Use the [`SpicepodCluster`](../kubernetes/spicepodcluster.md) CRD. The Spice Operator provisions mTLS certificates, child `SpicepodSet` resources for the scheduler and executor pools, services, and PodMonitors automatically. See [High Availability](../production/high-availability.md) for AZ spread, anti-affinity, and `PodDisruptionBudget` guidance.
 
-- **`GetCatalog`** — Fetches catalog, schema, and table metadata with Arrow schemas.
-- **`GetFunctions`** — Fetches UDF signatures, return types, and documentation.
+## Internal gRPC (port 50052)
 
-This ensures query planning and execution use a consistent view of the data model across all nodes.
+The internal `ClusterService` gRPC surface is mTLS-protected and never exposed externally. All cluster coordination flows through it:
+
+| RPC                             | Caller                        | Purpose                                                                                                                        |
+| ------------------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `GetAppDefinition`              | Executor at startup           | Fetches the full Spicepod definition (datasets, catalogs, views, UDFs) so executors do not need a local manifest.              |
+| `ExpandSecret`                  | Executor at startup           | Resolves a secret key through the scheduler's secret store.                                                                    |
+| `GetSchedulers`                 | Executor at startup           | Returns the list of live scheduler advertise addresses; executor opens a poll loop to each.                                    |
+| `AllocateInitialPartitions`     | Executor at startup           | Returns the executor's assigned per-table partition filter expressions (serialized DataFusion `Expr`).                         |
+| `ControlStream` (bidirectional) | Executor → Scheduler          | Carries heartbeats and metric responses; receives `UpdatePartitions`, `PollNow`, `RefreshDataset`, and `CancelTasks` commands. |
+| `GetTaskHistory`                | Scheduler → peer schedulers   | Federated `runtime.task_history` fan-out across the cluster.                                                                   |
+| `GetMetrics`                    | Scheduler → peers / executors | On-demand OTLP metrics collection.                                                                                             |
+
+## Partitioning, Sharding, and Partition-Aware Queries
+
+Distributed Spice clusters shard accelerated tables horizontally across executors using user-declared partition keys. Query planning is partition-aware: each executor only scans the partitions it owns, and the scheduler unions and merges results.
+
+### Declaring partitions
+
+Every accelerated dataset and view in cluster mode **must** declare at least one partition key via `acceleration.partition_by`. Startup fails otherwise with:
+
+> `Accelerated {component_type} '{name}' has no partition keys configured. Add 'partition_by' to its acceleration config to participate in cluster partition assignment.`
+
+Each entry is a SQL expression over the source schema. Entries can be anonymous, named, or column references:
+
+```yaml
+datasets:
+  - from: s3://lake/sales/
+    name: sales
+    acceleration:
+      enabled: true
+      engine: cayenne                       # required for write-through; any engine works for read-only
+      partition_by:
+        - "YEAR(order_date)"                # anonymous expression -> name `expr0`
+        - year: "YEAR(order_date)"          # named expression
+        - region: "region"                  # column value as partition key
+        - "bucket(100, customer_id)"        # static hash bucketing; no source query required
+```
+
+The `bucket(N, col)` function is treated as a **static** partition key: values `0..N-1` are enumerated without querying the source.
+
+### Partition discovery and assignment
+
+Partition assignment is **coordinated through the object store**: `cluster.json` is the single source of truth for which executor owns which partition. Schedulers never assign partitions purely from in-memory state, and executors never own a partition that is not durably committed to the object store first.
+
+The scheduler runs a `PartitionAssignmentTask` on `partition_assignment_interval` (default 30 s):
+
+1. **Discover** — For each accelerated table, runs `SELECT DISTINCT {expressions} FROM {federated_source}` against the source connector (within `partition_discovery_timeout`). Static `bucket(N, col)` keys skip the query.
+2. **Diff** — Compares discovered values against `cluster.json` (`accelerations` sub-map). New partitions are recorded as unassigned; stale partitions are removed.
+3. **Assign** — Picks executors for unassigned partitions using a greedy minimum set-cover algorithm, respecting `max_partitions_per_executor` and `max_partition_assignments_per_interval`. Tie-breaks are deterministic by executor ID.
+4. **Commit** — Writes the assignment (`assigned_executors` field of each partition entry) to `cluster.json` via an OCC conditional write (up to 8 retries). Concurrent schedulers serialize on this write: if two schedulers race on the same partition, one commits first and the other re-reads fresh state and retries, so an executor cannot be assigned the same partition twice.
+5. **Notify** — After the object-store commit succeeds, the scheduler pushes an `UpdatePartitions` message over the executor's `ControlStream` so it can immediately materialize the new partitions locally without waiting to re-read `cluster.json`.
+
+### How executors learn their assignments
+
+| Phase                   | Mechanism                                                                                                                                                                                                                            |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Startup / restart**   | Executor calls `AllocateInitialPartitions` (RPC pull) on its bootstrap scheduler, which reads from `cluster.json` and returns the executor's assigned partition filter expressions per table.                                        |
+| **Ongoing changes**     | Scheduler commits the change to `cluster.json` (OCC), then pushes `UpdatePartitions` over the `ControlStream`. The executor updates its in-memory `partition_assignments` map and registers/removes local accelerations accordingly. |
+| **Authoritative state** | `cluster.json` in the object store. The executor's in-memory map and the scheduler's `PartitionStore` cache are derived views; both are rebuilt from the object store after a process restart.                                       |
+
+### Partition-aware query planning
+
+The DataFusion analyzer rule `PartitionedTableScanRewrite` (scheduler-only) rewrites every `TableScan` on an accelerated table into a `UNION ALL` over per-executor FlightSQL scans, pushing down the executor's partition filter and any user predicates:
+
+```text
+Before:
+  TableScan: sales [filters: status = 'Disputed']
+
+After:
+  UNION ALL
+    TableScan: sales@executor-1 [filters: status='Disputed' AND year=2024 AND region='us-east']
+    TableScan: sales@executor-2 [filters: status='Disputed' AND year=2024 AND region='us-west']
+    TableScan: sales@executor-3 [filters: status='Disputed' AND year=2025 AND region='us-east']
+```
+
+When the plan contains a `Limit → Sort → Union` pattern (top-K), the `Sort` is pushed into each union leg and the executor returns at most `Limit` rows before the scheduler performs a final merge-sort.
+
+Executor selection uses a greedy minimum set-cover algorithm: pick the executor that covers the most still-required partitions, repeat until coverage is complete, break ties deterministically by executor ID. If any required partition is unassigned, the query fails with:
+
+> `Cannot execute query: N partition(s) not assigned to any executor`
+
+On executors, the `AcceleratedPartitionProvider` resolves partitions to local `TableProvider`s. Row-level partition predicates are not re-evaluated on executors — each executor only holds its own partitions, so filtering happens by ownership.
+
+### Partition-aware writes
+
+Write-through `INSERT`, `UPDATE`, `DELETE`, and `MERGE INTO` flow through the same partition-aware Arrow Flight `DoPut` path on the scheduler:
+
+1. The scheduler decodes the inbound `DoPut` schema header.
+2. For each `RecordBatch`, it evaluates the table's partition expressions against every row to classify rows into partitions.
+3. Rows for partitions already assigned to an executor are streamed via that executor's FlightSQL `DoPut`.
+4. Rows whose partition values are **new** are assigned on-the-fly to the least-loaded executor (recorded in `cluster.json` via OCC), then forwarded.
+5. All per-executor sub-streams run concurrently. Idle streams emit a keepalive sentinel to avoid the `DoPut` idle timeout (120 s default; override with `SPICE_DO_PUT_IDLE_TIMEOUT_SECS`).
+
+Write-through is currently constrained to the Cayenne accelerator (see [Distributed Accelerations](#distributed-accelerations)).
+
+### Constraints
+
+- Every accelerated table and view in cluster mode must declare `partition_by`.
+- Partition expressions must be deterministic SQL over the source schema.
+- `bucket(N, col)` is the supported static hash-partition function.
+- The scheduler holds **no** accelerated data; partition discovery queries always go to the federated source.
+- The DataFusion physical optimizer rule `EnsureSupportedFileScan` rejects plans containing file-scan nodes that cannot be distributed.
+
+## Distributed Accelerations
+
+In cluster mode, accelerated data is **sharded** across executors: each executor materializes only the partitions it owns. The scheduler's view of the table is a logical UNION ALL across executors; it never holds row data.
+
+### Engine support
+
+| Engine                | Cluster partition assignment | `write_mode: write_through` | Notes                                                                                             |
+| --------------------- | :--------------------------: | :-------------------------: | ------------------------------------------------------------------------------------------------- |
+| **Cayenne**           |              ✓               |              ✓              | Required for write-through. Vortex storage with SQLite metadata. Supports acceleration snapshots. |
+| **DuckDB**            |              ✓               |              —              | Read-only partitioned acceleration.                                                               |
+| **Arrow (in-memory)** |              ✓               |              —              | Read-only. Data is lost on pod restart unless backed by snapshots.                                |
+| **SQLite**            |              ✓               |              —              | Read-only.                                                                                        |
+| **Postgres**          |              ✓               |              —              | Read-only.                                                                                        |
+
+Attempting `write_mode: write_through` with a non-Cayenne engine fails fast at startup with `Write-through acceleration currently requires the Cayenne accelerator`.
+
+### Per-executor sharding
+
+Each partition has a single owning executor (1:1 assignment in `cluster.json`). Executor-local accelerations only contain rows that match their assigned partition filter expressions. Read paths fan out across executors; write paths route by partition key.
+
+### Refresh in cluster mode
+
+- The scheduler is the single source of truth for partition ownership; there is no separate refresh leader election.
+- After every source refresh cycle, the `PartitionAssignmentTask` re-runs discovery; new partition values are assigned, and `UpdatePartitions` is pushed to the receiving executor, which materializes the new partition.
+- The scheduler can also explicitly issue `RefreshDatasetCommand` over the `ControlStream` to trigger a refresh on a specific executor, which is how API-driven refresh requests are routed.
+
+### Acceleration snapshots (Cayenne)
+
+Cayenne supports object-store-backed acceleration snapshots that integrate naturally with cluster mode, allowing a newly started executor to bootstrap from the shared object store rather than re-fetching from the federated source:
+
+```yaml
+acceleration:
+  engine: cayenne
+  snapshots: enabled                   # enabled | disabled | bootstrap_only | create_only
+  snapshots_trigger: refresh_complete  # refresh_complete | time_interval | stream_batches
+  snapshots_compaction: enabled
+  snapshots_creation_policy: on_change # on_change | always
+```
+
+Setting `snapshots: bootstrap_only` is recommended on executors when the source is expensive to scan: executors hydrate from the snapshot at startup but do not produce new snapshots themselves. Cayenne's internal partition metadata supports composite keys (Hive-style `key1=v1/key2=v2/...` paths).
+
+### Sizing
+
+- Size each executor's local NVMe to hold its assigned partitions plus a shuffle working set (rule of thumb: ~25 % of dataset volume).
+- The scheduler does not need fast local storage; provision modest CPU / memory and ensure low-latency access to the object store.
+- See [Storage](../production/storage.md) for instance-type recommendations.
 
 ## Execution Modes
 
-| Mode             | Description                                                                      |
-| ---------------- | -------------------------------------------------------------------------------- |
-| **Synchronous**  | Client waits for the query to complete and receives results directly.            |
-| **Asynchronous** | Client submits a query and polls for results. Suitable for long-running queries. |
+| Mode             | Endpoint             | Notes                                                                                                                                                                        |
+| ---------------- | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Synchronous**  | `/v1/sql`, FlightSQL | Client waits for the query to complete and receives results directly. Available in any deployment.                                                                           |
+| **Asynchronous** | `/v1/jobs`           | Client submits a query and polls a `job_id` for status. Results are stored as chunked Arrow IPC under `jobs/` in the shared object store. **Cluster (scheduler) mode only.** |
 
-## Performance
+Async jobs require `runtime.scheduler.state_location` to be configured.
 
-Distributed query with Apache Ballista achieves **2.9x overall speedup** vs single-node DataFusion on TPC-H SF100 benchmarks, with shuffle data spilled to disk and failed stages retried without restarting.
+## Observability
 
-## Distributed Capabilities
+All distributed-query metrics are emitted through the OTel `cluster` meter and exposed on the standard Prometheus port (`9090`). The Grafana dashboard shipped with Spice.ai Enterprise (see [Observability](../production/observability.md)) plots the most important signals.
 
-The following operations are distributed across executor nodes:
+### Shared (scheduler and executor)
 
-- SQL query execution with shuffle-based data exchange
-- Cayenne data-local query routing
-- Partition-aware write-through (INSERT, UPDATE, DELETE)
-- MERGE INTO with distributed duplicate key detection
-- Distributed `runtime.task_history`
-- Executor DDL sync on connect
+| Metric               | Type          | Labels                          |
+| -------------------- | ------------- | ------------------------------- |
+| `node_status`        | Gauge         | `node_id`, `role`               |
+| `node_tasks_total`   | Counter       | `node_id`, `role`, `status`     |
+| `node_tasks_active`  | UpDownCounter | `node_id`, `role`               |
+| `node_task_failures` | Counter       | `node_id`, `role`, `error_type` |
+| `node_task_retries`  | Counter       | `node_id`, `role`               |
+
+### Scheduler
+
+| Metric                                                  | Type                |
+| ------------------------------------------------------- | ------------------- |
+| `scheduler_active_executors_count`                      | Gauge               |
+| `scheduler_count`                                       | Gauge               |
+| `scheduler_task_queue_depth`                            | Gauge               |
+| `scheduler_task_scheduling_latency_ms`                  | Histogram           |
+| `scheduler_stages_total`                                | Counter             |
+| `scheduler_stage_duration_ms`                           | Histogram           |
+| `scheduler_stage_failures`                              | Counter             |
+| `scheduler_stage_retries`                               | Counter             |
+| `scheduler_tasks_per_stage`                             | Histogram           |
+| `scheduler_planning_duration_ms`                        | Histogram           |
+| `scheduler_executor_assignments`                        | Counter             |
+| `scheduler_job_queue_depth`                             | Gauge               |
+| `scheduler_result_fetch_{bytes,rows,count,duration_ms}` | Counter / Histogram |
+
+### Executor
+
+| Metric                                                        | Type                |
+| ------------------------------------------------------------- | ------------------- |
+| `executor_tasks_active`                                       | UpDownCounter       |
+| `executor_tasks_total`                                        | Counter             |
+| `executor_task_failures`                                      | Counter             |
+| `executor_task_duration_ms`                                   | Histogram           |
+| `executor_memory_available_bytes`                             | Gauge               |
+| `executor_task_slots`                                         | Gauge               |
+| `executor_shuffle_write_{bytes,rows,duration_ms}`             | Counter / Histogram |
+| `executor_shuffle_read_local_{bytes,rows,count,duration_ms}`  | Counter / Histogram |
+| `executor_shuffle_read_remote_{bytes,rows,count,duration_ms}` | Counter / Histogram |
+
+### Federated `runtime.task_history`
+
+In cluster mode, `runtime.task_history` is replaced with a federated view. Queries fan out via `GetTaskHistory` to all peer schedulers and via FlightSQL to all connected executors; results are merged and sorted by `start_time DESC`. Every row is annotated with a `node_id` column identifying the originating advertise address. The local non-federated table remains accessible as `runtime.local_task_history` for debugging.
+
+If any peer or executor fails, the federated query fails — there are no partial results.
+
+## Limits and Caveats
+
+| Constraint                                                                                                        | Surface                                                                                 |
+| ----------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| Every accelerated dataset and view in cluster mode must declare `partition_by`.                                   | Startup error: `… has no partition keys configured`.                                    |
+| `write_mode: write_through` requires the Cayenne accelerator.                                                     | Startup error: `Write-through acceleration currently requires the Cayenne accelerator`. |
+| Two scheduler processes cannot share a `scheduler_id` while one is live.                                          | Startup error: `scheduler id {id} is already registered`.                               |
+| All partitions referenced by a query must be assigned to a connected executor at execution time.                  | Runtime error: `Cannot execute query: N partition(s) not assigned to any executor`.     |
+| Default `DoPut` idle timeout is 120 s; override with `SPICE_DO_PUT_IDLE_TIMEOUT_SECS`.                            | Long-running write streams must emit data or rely on the keepalive sentinel.            |
+| File-scan nodes that cannot be distributed are rejected by the `EnsureSupportedFileScan` physical optimizer rule. | Plan-time error during distributed planning.                                            |
+| `cluster.json` schema is versioned (`schema_version = 1`); other versions are rejected.                           | Cluster state from a different runtime major version is not accepted.                   |
+| Object stores backing `state_location` must implement conditional writes (ETag / `If-Match`).                     | Required for multi-active correctness.                                                  |
+
+## See also
+
+- [SpicepodCluster CRD reference](../kubernetes/spicepodcluster.md)
+- [High Availability](../production/high-availability.md)
+- [Storage](../production/storage.md)
+- [Observability](../production/observability.md)
+- [mTLS Cluster Security](mtls.md)
+- [Upgrades — Zero-downtime upgrade for distributed query](../production/upgrades.md#zero-downtime-upgrade-for-distributed-query)

--- a/enterprise/features/distributed-query.md
+++ b/enterprise/features/distributed-query.md
@@ -222,6 +222,10 @@ Write-through is currently constrained to the Cayenne accelerator (see [Distribu
 
 ## Distributed Accelerations
 
+{% hint style="info" %}
+Full reference: [Distributed Accelerations](distributed-accelerations.md).
+{% endhint %}
+
 In cluster mode, accelerated data is **sharded** across executors: each executor materializes only the partitions it owns. The scheduler's view of the table is a logical UNION ALL across executors; it never holds row data.
 
 ### Engine support

--- a/enterprise/features/distributed-query.md
+++ b/enterprise/features/distributed-query.md
@@ -248,6 +248,10 @@ Each partition has a single owning executor (1:1 assignment in `cluster.json`). 
 
 ### Acceleration snapshots (Cayenne)
 
+{% hint style="info" %}
+Acceleration snapshots are a **Spice.ai Enterprise** feature. They are not available in Spice.ai OSS.
+{% endhint %}
+
 Cayenne supports object-store-backed acceleration snapshots that integrate naturally with cluster mode, allowing a newly started executor to bootstrap from the shared object store rather than re-fetching from the federated source:
 
 ```yaml

--- a/enterprise/features/functions.md
+++ b/enterprise/features/functions.md
@@ -288,7 +288,7 @@ When `as_tool: true` (the default), every declared function is also registered a
 
 ## Distributed Execution
 
-In a Spice.ai Enterprise [distributed cluster](distributed-query.md), UDFs declared on the scheduler are automatically synchronised to executors via the `GetFunctions` Flight endpoint. Query planning and execution use a consistent view of the function set across all nodes.
+In a Spice.ai Enterprise [distributed cluster](distributed-query.md), UDFs declared on the scheduler are automatically propagated to executors as part of the `GetAppDefinition` bootstrap RPC — executors load the full Spicepod definition (datasets, catalogs, views, and UDFs) from the scheduler at startup, so query planning and execution use a consistent view of the function set across all nodes.
 
 User functions are deny-listed from federation pushdown on every node, so there's no risk of a stray executor attempting to push a user function into a downstream source.
 

--- a/enterprise/features/mtls.md
+++ b/enterprise/features/mtls.md
@@ -77,14 +77,17 @@ spiced --role executor \
 
 ## Internal Cluster Services (Port 50052)
 
-The internal gRPC services secured by mTLS:
+The internal gRPC services secured by mTLS. See [Distributed Query → Internal gRPC](distributed-query.md#internal-grpc-port-50052) for the full surface.
 
-| RPC                | Description                                                        |
-| ------------------ | ------------------------------------------------------------------ |
-| `GetAppDefinition` | Executors fetch the full Spicepod configuration from the scheduler |
-| `ExpandSecret`     | Executors request secret values from the scheduler's secret store  |
-| `GetCatalog`       | Fetch catalog/schema/table metadata with Arrow schemas             |
-| `GetFunctions`     | Fetch UDF signatures, return types, and documentation              |
+| RPC                             | Description                                                                                              |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `GetAppDefinition`              | Executors fetch the full Spicepod definition (datasets, catalogs, views, UDFs) from the scheduler.       |
+| `ExpandSecret`                  | Executors request secret values from the scheduler's secret store.                                       |
+| `GetSchedulers`                 | Executors fetch the live scheduler membership list to open a poll loop to every scheduler.              |
+| `AllocateInitialPartitions`     | Executors fetch their assigned partition filter expressions per accelerated table.                       |
+| `ControlStream` (bidirectional) | Carries executor heartbeats and metrics; receives partition update, refresh, and cancel commands.        |
+| `GetTaskHistory`                | Federated `runtime.task_history` fan-out across peer schedulers.                                         |
+| `GetMetrics`                    | On-demand OTLP metrics collection across the cluster.                                                    |
 
 {% hint style="danger" %}
 The `--allow-insecure-connections` flag disables all mTLS verification. Never use this in production — all inter-node communication will be unencrypted and unauthenticated.

--- a/enterprise/features/policy.md
+++ b/enterprise/features/policy.md
@@ -1,0 +1,223 @@
+---
+description: Cedar-based authorization policies for Spice.ai Enterprise — fine-grained access control over datasets, models, tools, and endpoints.
+icon: shield-keyhole
+---
+
+# Authorization Policy (Cedar)
+
+Spice.ai Enterprise enforces fine-grained authorization using [Cedar](https://www.cedarpolicy.com/), the open-source policy language developed by AWS. Policies decide, on every request, whether an authenticated principal may perform a given action on a Spice resource.
+
+{% hint style="info" %}
+Cedar-based authorization policy is a **Spice.ai Enterprise** feature. It is layered on top of [Authentication](authentication.md) — authentication establishes _who_ the principal is; policy decides _what_ they can do.
+{% endhint %}
+
+## Authorization Model
+
+Policy evaluation is the standard Cedar `(principal, action, resource, context)` decision. Spice.ai supplies an embedded Cedar schema that defines the entity types, actions, and attributes available in policies.
+
+### Entity types
+
+| Entity            | Description                                                                 | Notable attributes                       |
+| ----------------- | --------------------------------------------------------------------------- | ---------------------------------------- |
+| `Spice::User`     | An authenticated principal (OIDC subject, API key identity, …). `in [Role]` | `org_id`                                 |
+| `Spice::Role`     | A role or group the user belongs to (mapped from OIDC groups / API key tags) | —                                        |
+| `Spice::Dataset`  | A registered dataset (table) in the runtime                                 | `catalog`, `schema`                      |
+| `Spice::Model`    | An LLM model available for inference                                        | —                                        |
+| `Spice::Tool`     | A tool (built-in or MCP) available for execution                            | —                                        |
+| `Spice::Endpoint` | An API endpoint category (e.g. `chat`, `search`, `sql`)                     | —                                        |
+
+### Actions
+
+| Action                                                 | Applies to        | Description                              |
+| ------------------------------------------------------ | ----------------- | ---------------------------------------- |
+| `Spice::Action::"query"`                               | `Spice::Dataset`  | `SELECT` and read paths.                 |
+| `Spice::Action::"insert"`                              | `Spice::Dataset`  | `INSERT` write path.                     |
+| `Spice::Action::"update"`                              | `Spice::Dataset`  | `UPDATE` write path.                     |
+| `Spice::Action::"delete"`                              | `Spice::Dataset`  | `DELETE` write path.                     |
+| `Spice::Action::"ddl"`                                 | `Spice::Dataset`  | DDL operations on a dataset.             |
+| `Spice::Action::"invoke"`                              | `Spice::Model`    | Inference / chat completion.             |
+| `Spice::Action::"execute"`                             | `Spice::Tool`     | Tool invocation (built-in or MCP).       |
+| `Spice::Action::"access"`                              | `Spice::Endpoint` | Reaching an endpoint category.           |
+
+The Cedar schema is fixed by the runtime; policies reference these types and actions directly.
+
+## Configuration
+
+Policies are configured under `runtime.authorization` in `spicepod.yaml`. Authentication must be configured separately under `runtime.auth` — see [Authentication](authentication.md).
+
+```yaml
+runtime:
+  auth:
+    oidc:
+      issuer: https://auth.example.com/
+      audience: spice-runtime
+
+  authorization:
+    enabled: true              # default: true
+    default: allow             # allow | deny  — decision when no policy matches
+    provider: local            # local | operator | cloud
+    policies:
+      - name: analysts-read-only
+        cedar: |
+          permit(
+            principal in Spice::Role::"analyst",
+            action == Spice::Action::"query",
+            resource
+          );
+      - name: block-pii
+        path: ./policies/block-pii.cedar
+```
+
+### `runtime.authorization` fields
+
+| Field      | Type                                          | Default | Description                                                                                           |
+| ---------- | --------------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------- |
+| `enabled`  | bool                                          | `true`  | Toggles policy evaluation.                                                                            |
+| `default`  | `allow` \| `deny`                             | `allow` | Decision when no policy matches. Set to `deny` for production deny-by-default deployments.            |
+| `provider` | `local` \| `operator` \| `cloud`              | `local` | Source of policies. `local` reads inline / file; `operator` polls the Spice K8s Operator; `cloud` polls the Spice Cloud Management API. |
+| `policies` | list of [`PolicyDefinition`](#policydefinition) | `[]`    | Policy entries (used with `provider: local`).                                                         |
+| `operator` | object                                        | —       | Operator provider config. Fields: `endpoint`, `poll_interval` (default `30s`).                        |
+| `cloud`    | object                                        | —       | Cloud provider config. Fields: `poll_interval` (default `60s`).                                       |
+
+#### PolicyDefinition
+
+| Field   | Type   | Description                                                                                  |
+| ------- | ------ | -------------------------------------------------------------------------------------------- |
+| `name`  | string | Human-readable identifier used in logs and decision diagnostics.                             |
+| `cedar` | string | Inline Cedar policy text. Mutually compatible with `path`; both may be used together.        |
+| `path`  | string | Path to a `.cedar` file, resolved relative to `spicepod.yaml`. Mutually compatible with `cedar`. |
+
+## Policy Examples
+
+### Default-deny baseline
+
+```yaml
+runtime:
+  authorization:
+    default: deny
+    policies:
+      - name: admins-everything
+        cedar: |
+          permit(
+            principal in Spice::Role::"admin",
+            action,
+            resource
+          );
+```
+
+### Read-only analysts
+
+```cedar
+permit(
+  principal in Spice::Role::"analyst",
+  action == Spice::Action::"query",
+  resource
+);
+
+forbid(
+  principal in Spice::Role::"analyst",
+  action in [
+    Spice::Action::"insert",
+    Spice::Action::"update",
+    Spice::Action::"delete",
+    Spice::Action::"ddl"
+  ],
+  resource
+);
+```
+
+### Restrict a dataset to a single role
+
+```cedar
+forbid(
+  principal,
+  action,
+  resource == Spice::Dataset::"sales.public.orders"
+)
+unless { principal in Spice::Role::"sales-ops" };
+```
+
+### Block PII columns from non-privileged roles
+
+```cedar
+forbid(
+  principal,
+  action == Spice::Action::"query",
+  resource
+)
+when {
+  resource.catalog == "customers" &&
+  resource.schema == "pii" &&
+  !(principal in Spice::Role::"compliance")
+};
+```
+
+### Limit model invocation to a paid tier
+
+```cedar
+permit(
+  principal in Spice::Role::"premium",
+  action == Spice::Action::"invoke",
+  resource == Spice::Model::"gpt-4o"
+);
+```
+
+### Endpoint-level access (e.g. lock down `/v1/sql`)
+
+```cedar
+forbid(
+  principal,
+  action == Spice::Action::"access",
+  resource == Spice::Endpoint::"sql"
+)
+unless { principal in Spice::Role::"engineer" };
+```
+
+## Policy Providers
+
+| Provider   | Use case                                                   | Reload                                                                       |
+| ---------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `local`    | Inline Cedar text and/or `.cedar` files in the spicepod.    | Reloaded on Spicepod restart or operator-driven config rollout.              |
+| `operator` | Centralized policy distribution via the Spice K8s Operator. | Polled at `poll_interval` (default `30s`); engine atomically swaps the set.  |
+| `cloud`    | Centralized policy distribution via Spice Cloud.            | Polled at `poll_interval` (default `60s`); engine atomically swaps the set.  |
+
+Policy reloads are **atomic**: in-flight requests complete against the previous policy set, and subsequent requests evaluate against the new set. Empty policy fetches do not silently disable enforcement — combined with `default: deny`, an empty set denies everything.
+
+## Combining Policy with Identity SQL Functions
+
+Cedar handles coarse-grained allow/deny decisions across actions and resources. For **row-level** filtering, combine policy with the [identity SQL functions](authentication.md#identity-sql-functions) in dataset views or `WHERE` clauses:
+
+```yaml
+views:
+  - name: my_orders
+    sql: |
+      SELECT *
+      FROM sales.orders
+      WHERE owner_email = current_principal_email()
+        OR 'sales-ops' = ANY(current_principal_groups())
+```
+
+A typical layered model:
+
+1. Cedar policy decides whether the principal may `query` a dataset at all.
+2. SQL views with identity functions filter the rows the principal may see.
+
+## Distributed Cluster Behavior
+
+In a [`SpicepodCluster`](../kubernetes/spicepodcluster.md), the scheduler is the source of truth for policy. Executors pull policy as part of the `GetAppDefinition` bootstrap RPC and re-evaluate when policy changes are pushed; the same Cedar decision applies regardless of which scheduler routes a request. Policy diagnostics (matched policy IDs, decision) are emitted as structured logs and surface in `runtime.task_history`.
+
+## Production Checklist
+
+- [ ] `runtime.authorization.enabled: true` and `default: deny` for production deployments.
+- [ ] Roles are sourced from a trusted identity provider (OIDC groups or API key tags) — see [Authentication](authentication.md).
+- [ ] Policy files are stored in Git and rolled out via GitOps (Argo CD / Flux) rather than ad-hoc edits on the cluster.
+- [ ] An "admin escape hatch" `permit` rule exists and is restricted to a small `Spice::Role::"admin"` group with audited membership.
+- [ ] Policy decision logs are forwarded to the SIEM together with authentication logs.
+- [ ] Cedar policies are validated in CI with `cedar validate` against the embedded Spice schema before merge.
+
+## See also
+
+- [Authentication](authentication.md)
+- [Security](../production/security.md)
+- [Distributed Query](distributed-query.md)
+- [Cedar policy language reference](https://docs.cedarpolicy.com/)

--- a/enterprise/kubernetes/README.md
+++ b/enterprise/kubernetes/README.md
@@ -29,17 +29,26 @@ docker pull 709825985650.dkr.ecr.us-east-1.amazonaws.com/spice-ai/spiceai-operat
 
 ### Helm Values
 
-| Parameter                    | Description                           | Default                                                                  |
-| ---------------------------- | ------------------------------------- | ------------------------------------------------------------------------ |
-| `image.repository`           | Operator image repository             | `709825985650.dkr.ecr.us-east-1.amazonaws.com`                            |
-| `image.name`                 | Operator image name                   | `spice-ai/spiceai-operator`                                              |
-| `image.tag`                  | Operator image tag                    | `latest`                                                                 |
-| `image.pullSecrets`          | Image pull secrets                    | —                                                                        |
-| `installCRDs`                | Install/update CRDs with the chart    | `true`                                                                   |
-| `serviceAccount.annotations` | Annotations (e.g. for IRSA)           | `{}`                                                                     |
-| `servicemonitor.enabled`     | Enable Prometheus `ServiceMonitor`    | `false`                                                                  |
-| `cluster.clusterDomain`      | Kubernetes cluster domain             | `cluster.local`                                                          |
-| `telemetryProperties`        | Key/value pairs for the Spice runtime | —                                                                        |
+| Parameter                              | Description                                                                       | Default                                                       |
+| -------------------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| `image.repository`                     | Operator image repository                                                         | `709825985650.dkr.ecr.us-east-1.amazonaws.com`                |
+| `image.name`                           | Operator image name                                                               | `spice-ai/spiceai-operator`                                   |
+| `image.tag`                            | Operator image tag                                                                | `latest`                                                      |
+| `image.pullPolicy`                     | Operator image pull policy                                                        | `IfNotPresent`                                                |
+| `image.pullSecrets`                    | Image pull secrets                                                                | —                                                             |
+| `installCRDs`                          | Install/update CRDs with the chart                                                | `true`                                                        |
+| `serviceAccount.create`                | Create a ServiceAccount for the operator                                          | `true`                                                        |
+| `serviceAccount.name`                  | ServiceAccount name                                                               | (chart name)                                                  |
+| `serviceAccount.annotations`           | Annotations for the operator ServiceAccount (e.g. for IRSA)                       | `{}`                                                          |
+| `resources`                            | CPU/memory `requests` and `limits` for the operator container                     | —                                                             |
+| `nodeSelector` / `tolerations` / `affinity` | Operator pod scheduling                                                      | —                                                             |
+| `serviceMonitor.enabled`               | Enable Prometheus `ServiceMonitor`                                                | `false`                                                       |
+| `serviceMonitor.interval`              | Scrape interval                                                                   | `30s`                                                         |
+| `cluster.domain`                       | Kubernetes cluster domain for internal DNS                                        | `cluster.local`                                               |
+| `pauseCrashloopingPodsThreshold`       | Crashlooping pod threshold before pausing a `SpicepodSet` (`0` disables)          | `10`                                                          |
+| `sidecarInjector.defaultImage`         | Default image used by the sidecar injector when no per-Pod override is set        | (operator default)                                            |
+| `sidecarInjector.defaultImagePullPolicy` | Default pull policy for injected sidecars                                       | (operator default)                                            |
+| `telemetryProperties`                  | Key/value pairs forwarded to the Spice runtime as telemetry properties            | `{}`                                                          |
 
 ## Managed Resources
 
@@ -55,15 +64,15 @@ For each `SpicepodSet`, the operator creates and manages:
 
 ## Adaptive Workload Deployment
 
-For simple stateless cases (no `volume`, no `cluster`, `replicas <= 1`), the operator uses a `Deployment`. When volumes, cluster mode, or multiple replicas are configured, it creates per-replica `StatefulSet`s with stable pod identities and ordered startup.
+For simple stateless cases (no `volume`, no `cluster`, `replicas <= 1`), the operator uses a `Deployment`. When `volume`, `cluster`, or `replicas > 1` is configured, the operator creates per-replica `StatefulSet`s with stable pod identities and ordered startup. Switching between modes is automatic when the spec changes.
 
 ## Features
 
 | Feature                                    | SpicepodSet | SpicepodCluster |
 | ------------------------------------------ | :---------: | :-------------: |
 | Adaptive workload deployment               |      ✓      |        ✓        |
-| High-availability rollouts                 |      ✓      |        ✓        |
-| Configurable update strategies             |      ✓      |        ✓        |
+| Update strategies (`RollingOrdered`, `RollingParallel`, `Parallel`, `BlueGreen`) | ✓ | ✓ |
+| Instant rollback via `spice.ai/rollback`   |      ✓      |        ✓        |
 | Persistent volume with auto-resize         |      ✓      |        ✓        |
 | Zero-replica pausing                       |      ✓      |        ✓        |
 | Crashloop protection                       |      ✓      |        ✓        |
@@ -72,9 +81,63 @@ For simple stateless cases (no `volume`, no `cluster`, `replicas <= 1`), the ope
 | Service account configuration (incl. IRSA) |      ✓      |        ✓        |
 | Health probe customization                 |      ✓      |        ✓        |
 | Pod scheduling (affinity, tolerations)     |      ✓      |        ✓        |
+| Sidecar injection via Pod annotations      |      —      |        —        |
 | Automatic mTLS certificates                |      —      |        ✓        |
 | Distributed scheduler/executor topology    |      —      |        ✓        |
 | Prometheus metrics & ServiceMonitor        |      ✓      |        ✓        |
+
+## Sidecar Injection
+
+The operator can inject a Spice sidecar into any standard Kubernetes Pod by annotating the Pod template with `spice.ai/inject` and pointing it at a `ConfigMap` in the same namespace that holds your `spicepod.yaml`. For the common case, `spice.ai/inject` can name the ConfigMap directly:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: demo-spice-config
+data:
+  spicepod.yaml: |
+    name: demo-sidecar
+    kind: Spicepod
+    version: v1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-with-spice
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: app-with-spice }
+  template:
+    metadata:
+      labels: { app: app-with-spice }
+      annotations:
+        spice.ai/inject: demo-spice-config
+    spec:
+      containers:
+        - name: app
+          image: nginx:stable
+```
+
+### Supported annotations
+
+| Annotation                     | Default          | Description                                                                                  |
+| ------------------------------ | ---------------- | -------------------------------------------------------------------------------------------- |
+| `spice.ai/inject`              | —                | `true`/`enabled`, `false`/`disabled`, **or** a ConfigMap name (one-annotation shorthand).     |
+| `spice.ai/spicepod-configmap`  | —                | ConfigMap holding the spicepod. Optional when `spice.ai/inject` already names the ConfigMap. |
+| `spice.ai/spicepod-key`        | `spicepod.yaml`  | Key inside the ConfigMap data.                                                               |
+| `spice.ai/image`               | install default  | Override the injected Spice image.                                                           |
+| `spice.ai/image-pull-policy`   | install default  | Override the injected image pull policy.                                                     |
+| `spice.ai/http-port`           | `18090`          | Sidecar HTTP port.                                                                           |
+| `spice.ai/flight-port`         | `15051`          | Sidecar Arrow Flight port.                                                                   |
+| `spice.ai/metrics-port`        | `19090`          | Sidecar Prometheus metrics port.                                                             |
+
+{% hint style="info" %}
+Injection runs on Pod creation, so place these annotations on the controller's Pod template (e.g. `Deployment.spec.template.metadata.annotations`) and `kubectl rollout restart` to pick up changes. The ConfigMap must already exist when the Pod is created. The webhook rejects Pods whose existing container ports collide with the requested sidecar ports.
+{% endhint %}
+
+Cluster operators can set defaults globally via Helm values `sidecarInjector.defaultImage` and `sidecarInjector.defaultImagePullPolicy`, with per-workload annotations as overrides.
 
 ## Operator CLI
 
@@ -88,24 +151,32 @@ spiceai-operator crd --output FILE
 
 ### `run` — Start the operator controller
 
-| Flag                                  | Default                   | Description                          |
-| ------------------------------------- | ------------------------- | ------------------------------------ |
-| `--enable-leader-election`            | `false`                   | Enable leader election for HA        |
-| `--http-endpoint`                     | `0.0.0.0:8090`            | Operator HTTP API address            |
-| `--metrics-endpoint`                  | `0.0.0.0:9090`            | Prometheus metrics address           |
-| `--operator-namespace`                | `spiceai-operator-system` | Namespace for the operator           |
-| `--cluster-domain`                    | `cluster.local`           | Kubernetes cluster domain            |
-| `--pause-crashlooping-pods-threshold` | `10`                      | Dead pod observations before pausing |
-| `--telemetry-properties KEY=VALUE`    | —                         | Key/value pairs for the runtime      |
-| `--verbose`                           | `false`                   | Enable debug-level logging           |
+| Flag                                  | Default                   | Description                                                  |
+| ------------------------------------- | ------------------------- | ------------------------------------------------------------ |
+| `--http-endpoint`                     | `0.0.0.0:8090`            | Operator HTTP API bind address                                |
+| `--metrics-endpoint`                  | `0.0.0.0:9090`            | Prometheus metrics bind address                              |
+| `--operator-namespace`                | `spiceai-operator-system` | Namespace for the operator (used for cluster-shared secrets) |
+| `--cluster-domain`                    | `cluster.local`           | Kubernetes cluster domain                                    |
+| `--pause-crashlooping-pods-threshold` | `10`                      | Dead pod observations before pausing (`0` disables)          |
+| `--telemetry-properties KEY=VALUE`    | —                         | Key/value pairs forwarded to the Spice runtime               |
+| `--verbose`                           | `false`                   | Enable debug-level logging                                   |
+
+### `json-schema` — Output the OpenAPI v3 JSON schema for the `SpicepodSet` CRD
+
+```bash
+spiceai-operator json-schema              # Print to stdout
+spiceai-operator json-schema --output FILE
+```
 
 ## Operator HTTP API
 
-| Endpoint                                   | Method | Description                    |
-| ------------------------------------------ | ------ | ------------------------------ |
-| `/health`                                  | GET    | Health check — returns `OK`    |
-| `/{namespace}/{name}`                      | GET    | Pod status for a `SpicepodSet` |
-| `/{namespace}/{name}?kind=SpicepodCluster` | GET    | Status for a `SpicepodCluster` |
+| Endpoint                                   | Method | Description                                                                              |
+| ------------------------------------------ | ------ | ---------------------------------------------------------------------------------------- |
+| `/health`                                  | GET    | Health check — returns `OK`                                                              |
+| `/{namespace}/{name}`                      | GET    | Pod status for a `SpicepodSet`                                                           |
+| `/{namespace}/{name}?kind=SpicepodCluster` | GET    | Pod status for a `SpicepodCluster`                                                       |
+
+The pod-status response includes per-pod details (name, UID, phase, IP, port, start time, Spiced health/readiness, and any error reason/message). For paused `SpicepodSet`s (`replicas: 0`), the response includes `paused: true` with a `pauseReason`.
 
 ## Upgrading
 

--- a/enterprise/kubernetes/spicepodcluster.md
+++ b/enterprise/kubernetes/spicepodcluster.md
@@ -106,10 +106,13 @@ Never use `allowInsecureConnections: true` in production. All inter-node communi
 | 9090  | Public       | Prometheus metrics              | No            |
 | 50052 | **Internal** | Scheduler gRPC, Cluster Service | **Required**  |
 
-The internal port (50052) carries cluster coordination traffic:
+The internal port (50052) carries cluster coordination traffic. See [Distributed Query → Internal gRPC](../features/distributed-query.md#internal-grpc-port-50052) for the full RPC surface, including:
 
-- **`GetAppDefinition`** — Executors fetch the full Spicepod configuration from the scheduler.
+- **`GetAppDefinition`** — Executors fetch the full Spicepod definition (datasets, catalogs, views, UDFs) from the scheduler.
 - **`ExpandSecret`** — Executors request secret values from the scheduler's secret store.
+- **`GetSchedulers`** / **`AllocateInitialPartitions`** — Executors fetch scheduler membership and their assigned partitions at startup.
+- **`ControlStream`** — Bidirectional channel carrying executor heartbeats and `UpdatePartitions` / `RefreshDataset` / `CancelTasks` commands.
+- **`GetTaskHistory`** / **`GetMetrics`** — Federated `runtime.task_history` and on-demand metrics fan-out across the cluster.
 
 ## Verification
 

--- a/enterprise/kubernetes/spicepodcluster.md
+++ b/enterprise/kubernetes/spicepodcluster.md
@@ -27,7 +27,7 @@ A `SpicepodCluster` deploys a distributed query cluster with dedicated scheduler
 └──────────┘     └──────────┘     └──────────┘
 ```
 
-Schedulers coordinate query planning and execution; executors perform the compute work. Executors initiate connections to all schedulers and are shared across them.
+Schedulers coordinate query planning and partition assignment; executors perform the compute work. Executors initiate connections to all schedulers and are shared across them — partition ownership is committed to a shared object store and pushed to executors via the cluster `ControlStream`. See [Distributed Query](../features/distributed-query.md) for the full execution model.
 
 ## Example
 
@@ -40,7 +40,7 @@ metadata:
 spec:
   schedulerSetSpec:
     replicas: 1
-    spicepod: |
+    spicepod:
       version: v1
       kind: Spicepod
       name: my-cluster-scheduler
@@ -131,4 +131,34 @@ kubectl get pods -l spice.ai/cluster-role=executor
 
 ## Configuration Inheritance
 
-`SpicepodCluster` creates child `SpicepodSet` resources for schedulers and executors. All `SpicepodSet` configuration options (resources, volumes, service accounts, update strategies, health probes, pod scheduling) are available in `schedulerSetSpec` and `executorSetSpec`.
+`SpicepodCluster` creates child `SpicepodSet` resources for schedulers and executors. Both `schedulerSetSpec` and `executorSetSpec` accept the same subset of [`SpicepodSet` fields](spicepodset.md): `image`, `httpPort`, `flightPort`, `metricsPort`, `replicas`, `resources`, `env`, `envFromSource`, `network`, `nodeAffinity`, `tolerations`, `volume`, `serviceAccount`, `annotations`, `labels`, `updateStrategy`, `probes`, `terminationGracePeriodSeconds`, and `cluster`.
+
+The `executorSetSpec` does **not** accept a `spicepod` field — executors fetch the Spicepod definition from the scheduler at startup via `GetAppDefinition`.
+
+### Per-node `cluster` overrides
+
+The `cluster` field on `schedulerSetSpec` / `executorSetSpec` is a small subset (`NodeClusterConfig`) used to override cluster-internal addresses; the operator otherwise auto-populates cluster identity, role, mTLS, and scheduler discovery:
+
+```yaml
+spec:
+  schedulerSetSpec:
+    cluster:
+      bindAddress: "0.0.0.0:50052"
+```
+
+## Status
+
+```bash
+kubectl get spicepodcluster my-cluster -o yaml
+```
+
+| Field                       | Description                                                                |
+| --------------------------- | -------------------------------------------------------------------------- |
+| `rootCertificateReady`      | Whether the cluster's root CA has been generated.                          |
+| `rootSecretName`            | Secret holding the root CA certificate and private key.                    |
+| `rootExpiresAt`             | RFC 3339 expiration of the root CA.                                        |
+| `schedulerSpicepodsetName`  | Name of the child scheduler `SpicepodSet`.                                 |
+| `executorSpicepodsetName`   | Name of the child executor `SpicepodSet`.                                  |
+| `schedulerReadyReplicas`    | Ready scheduler replicas.                                                  |
+| `executorReadyReplicas`     | Ready executor replicas.                                                   |
+| `error`                     | Error message if certificate generation or reconciliation failed.          |

--- a/enterprise/kubernetes/spicepodset.md
+++ b/enterprise/kubernetes/spicepodset.md
@@ -5,7 +5,12 @@ icon: layer-group
 
 # SpicepodSet
 
-A `SpicepodSet` deploys and manages one or more Spicepod replicas. The operator handles the full lifecycle: creating the workload, rolling updates, volume management, health monitoring, and crashloop protection.
+A `SpicepodSet` (`spice.ai/v1`) deploys and manages one or more Spicepod replicas. The operator handles the full lifecycle: creating the workload, rolling updates, volume management, health monitoring, and crashloop protection.
+
+The operator chooses the underlying workload type adaptively:
+
+- A single `Deployment` for the simple case (no `volume`, no `cluster`, `replicas <= 1`).
+- Per-replica `StatefulSet`s when `volume`, `cluster`, or `replicas > 1` is configured, providing stable pod identities and ordered startup.
 
 ## Minimal Example
 
@@ -17,33 +22,50 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  spicepod: |
+  spicepod:
     name: my-spicepod
     kind: Spicepod
     version: v1
 ```
 
-## Container Image
+The `spicepod` field accepts the inline Spicepod definition (datasets, catalogs, models, views, etc.) and is preserved as-is by the operator.
 
-Configure a custom Spice.ai Enterprise image:
+## Container Image
 
 ```yaml
 spec:
-  spiceai_image_registry: 709825985650.dkr.ecr.us-east-1.amazonaws.com
-  spiceai_image_name: spice-ai/spiceai-enterprise-byol
-  spiceai_image_tag: latest-models
-  spiceai_image_pull_secret: my-pull-secret
+  image:
+    registry: 709825985650.dkr.ecr.us-east-1.amazonaws.com
+    name: spice-ai/spiceai-enterprise-byol
+    tag: latest-models
+    pullPolicy: IfNotPresent          # Always | Never | IfNotPresent
+    pullSecret: my-pull-secret
 ```
+
+| Field        | Default                                     | Description                                                              |
+| ------------ | ------------------------------------------- | ------------------------------------------------------------------------ |
+| `tag`        | `latest-models`                             | Image tag.                                                               |
+| `name`       | `spiceai/spiceai`                           | Image name.                                                              |
+| `registry`   | Docker Hub                                  | Image registry.                                                          |
+| `pullPolicy` | `Always` for `:latest`, else `IfNotPresent` | Image pull policy.                                                       |
+| `pullSecret` | —                                           | Name of a Kubernetes Secret holding credentials for a private registry.  |
 
 ## Ports
 
 ```yaml
 spec:
-  spiced:
-    http_port: 8090
-    flight_port: 50051
-    metrics_port: 9090
+  httpPort: 8090
+  flightPort: 50051
+  metricsPort: 9090
 ```
+
+| Field         | Default | Description                |
+| ------------- | ------- | -------------------------- |
+| `httpPort`    | `8090`  | HTTP API port.             |
+| `flightPort`  | `50051` | Apache Arrow Flight port.  |
+| `metricsPort` | `9090`  | Prometheus metrics port.   |
+
+The Service exposes fixed ports `8080` (HTTP), `50051` (Flight), and `9090` (metrics) and maps `targetPort` to the configured Spiced ports above.
 
 ## Resources
 
@@ -64,13 +86,13 @@ spec:
 spec:
   env:
     - name: SPICE_LOG_LEVEL
-      value: "debug"
+      value: debug
     - name: MY_SECRET
       valueFrom:
         secretKeyRef:
           name: my-secret
           key: api-key
-  env_from_source:
+  envFromSource:
     - configMapRef:
         name: my-config
     - secretRef:
@@ -84,132 +106,149 @@ Enable persistent volumes with automatic resizing:
 ```yaml
 spec:
   volume:
-    storage_class_name: standard
-    storage_requests: 10Gi
+    storageClassName: standard
+    storageRequests: 10Gi
 ```
 
 {% hint style="warning" %}
-Volume shrinking is not supported. Decreasing `storage_requests` has no effect on existing PVCs.
+Volume shrinking is not supported. Decreasing `storageRequests` has no effect on existing PVCs.
 {% endhint %}
 
-When volumes are configured, the operator creates per-replica `StatefulSet`s with `PersistentVolumeClaim`s. Increasing `storage_requests` triggers automatic PVC resizing.
+When `volume` is configured, the operator deploys per-replica `StatefulSet`s with `PersistentVolumeClaim`s. Increasing `storageRequests` triggers automatic PVC resizing.
 
 ## Service Account
 
-### Operator-Managed
-
 ```yaml
+# Operator-managed
 spec:
-  service_account:
+  serviceAccount:
     enabled: true
     create: true
-```
 
-### Bring Your Own
-
-```yaml
+# Bring your own
 spec:
-  service_account:
+  serviceAccount:
     enabled: true
     create: false
     name: my-existing-service-account
-```
 
-### With IRSA Annotations
-
-```yaml
+# With IRSA annotations
 spec:
-  service_account:
+  serviceAccount:
     enabled: true
     create: true
     annotations:
-      eks.amazonaws.com/role-arn: "arn:aws:iam::123456789012:role/spice-ai-role"
+      eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/spice-ai-role
 ```
 
-{% hint style="info" %}
-To annotate only the ServiceAccount (e.g. for IRSA), use `service_account.annotations` instead of `spec.annotations`.
-{% endhint %}
+| Field         | Default            | Description                                                                                    |
+| ------------- | ------------------ | ---------------------------------------------------------------------------------------------- |
+| `enabled`     | `false`            | Whether to use a ServiceAccount.                                                               |
+| `create`      | `false`            | Whether to create a new ServiceAccount. If `false`, set `name` to reference an existing one.   |
+| `name`        | `SpicepodSet` name | ServiceAccount name; required when `create: false`.                                            |
+| `annotations` | —                  | Annotations applied **only** to the ServiceAccount (ideal for IRSA `eks.amazonaws.com/role-arn`). |
 
 ## Update Strategies
 
-| Strategy                      | Behavior                                                                              |
-| ----------------------------- | ------------------------------------------------------------------------------------- |
-| **RollingParallel** (default) | Updates pods in parallel, keeping at least one available. Supports `max_unavailable`. |
-| **RollingOrdered**            | Updates pods one at a time in ordinal order, waiting for each to become ready.        |
-| **Parallel**                  | Updates all pods simultaneously with no availability constraints.                     |
-
 ```yaml
-# RollingParallel (default)
 spec:
-  replicas: 5
-  update_strategy:
-    type: RollingParallel
-    max_unavailable: 2
-
-# RollingOrdered
-spec:
-  update_strategy:
-    type: RollingOrdered
-
-# Parallel
-spec:
-  update_strategy:
-    type: Parallel
+  updateStrategy:
+    type: RollingOrdered    # default
 ```
 
-During rolling updates, new and unready replicas are updated first. Existing healthy replicas are only removed once replacements are ready.
+| Strategy                 | Behavior                                                                                                                            |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| **`RollingOrdered`** (default) | Updates pods one at a time in ordinal order, waiting for each to become Ready before proceeding.                          |
+| **`RollingParallel`**    | Updates pods in parallel. Set `maxUnavailable` to bound concurrent unavailable pods.                                                |
+| **`Parallel`**           | Updates all pods simultaneously with no availability constraints.                                                                   |
+| **`BlueGreen`**          | Brings up a parallel `StatefulSet` for the new generation, then atomically switches Service traffic once **all** new-generation pods are Ready. PVCs are ephemeral across generations. |
+
+```yaml
+spec:
+  replicas: 5
+  updateStrategy:
+    type: RollingParallel
+    maxUnavailable: 2
+    minReadyForCutover: 3   # optional
+```
+
+### `minReadyForCutover`
+
+Switches the Service to the new generation as soon as `minReadyForCutover` new-generation pods are Ready, instead of waiting for all of them.
+
+- **For `BlueGreen` and instant-rollback**: switches the version-pinned Service selector and promotes `status.activeVersion` early.
+- **For `RollingOrdered` / `RollingParallel`**: causes the Service object to be created earlier in the rollout (selector is not version-pinned, so traffic is already routed to all matching Ready pods once the Service exists).
+- **Ignored** for `Parallel`. A value of `0` is treated as unset. Values larger than `replicas` collapse to "wait for all".
+
+## Instant Rollback
+
+Retain the previous-generation pods after a rollout so traffic can be cut back to them instantly without rolling pods.
+
+```yaml
+spec:
+  updateStrategy:
+    type: BlueGreen
+  instantRollback:
+    enabled: true
+    retentionPeriodSeconds: 900   # default 15 minutes
+```
+
+After a successful rollout, set the rollback annotation on the `SpicepodSet` to swap traffic back to the standby:
+
+```bash
+kubectl annotate spicepodset my-spicepod spice.ai/rollback=true --overwrite
+```
+
+The operator switches the Service to the standby pods, clears the annotation, and tracks `status.activeVersion` / `status.standbyVersion` / `status.standbyExpiresAt`. Standby pods are torn down after `retentionPeriodSeconds` if no rollback occurs.
+
+{% hint style="info" %}
+Combine `instantRollback` with `BlueGreen` for the canonical zero-downtime production rollout pattern.
+{% endhint %}
 
 ## Scaling and Pausing
 
-Set `replicas: 0` to scale down to zero pods while retaining supporting resources (Service, ConfigMap, NetworkPolicy, ServiceAccount):
+Set `replicas: 0` to pause the workload while retaining supporting resources (Service, ConfigMap, NetworkPolicy, ServiceAccount):
 
 ```yaml
 spec:
   replicas: 0
 ```
 
-## Network Policy
+## Network and DNS
 
-Configure egress and ingress rules:
+Egress, ingress, DNS policy, and DNS config are nested under `network`:
 
 ```yaml
 spec:
-  egress:
-    - to:
-        - ipBlock:
-            cidr: 10.0.0.0/8
-      ports:
-        - protocol: TCP
-          port: 443
-  ingress:
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              name: my-namespace
-      ports:
-        - protocol: TCP
-          port: 8090
+  network:
+    egress:
+      - to:
+          - ipBlock:
+              cidr: 10.0.0.0/8
+        ports:
+          - protocol: TCP
+            port: 443
+    ingress:
+      - from:
+          - namespaceSelector:
+              matchLabels:
+                name: my-namespace
+        ports:
+          - protocol: TCP
+            port: 8090
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+        - 8.8.8.8
+      searches:
+        - my-domain.local
 ```
 
-Disable the Service:
+Disable the Service entirely:
 
 ```yaml
 spec:
-  enable_service: false
-```
-
-## DNS Configuration
-
-Override pod-level DNS:
-
-```yaml
-spec:
-  dnsPolicy: None
-  dnsConfig:
-    nameservers:
-      - 8.8.8.8
-    searches:
-      - my-domain.local
+  enableService: false
 ```
 
 ## Annotations and Labels
@@ -219,13 +258,17 @@ Updating `annotations` or `labels` triggers a full pod rollout, even when no oth
 ```yaml
 spec:
   annotations:
-    custom-annotation: "test-value"
+    custom-annotation: test-value
   labels:
     environment: production
     team: data-platform
 ```
 
+Operator-reserved keys (e.g. `spice.ai/app`, `spice.ai/spicepod`, `spice.ai/version`, `spice.ai/cluster`, `spice.ai/cluster-role`, `spice.ai/cluster-mtls`, `spice.ai/component`, `spice.ai/observed-generation`, `spice.ai/rollback`, `spice.ai/sidecar-injected`, `spice.ai/validation-level`) are stripped from user-supplied annotations/labels.
+
 ## Health Probes
+
+Probes are only created when the Spiced HTTP server is enabled (i.e. for non-executor nodes). Cluster executors have no probes.
 
 ```yaml
 spec:
@@ -250,25 +293,43 @@ spec:
         - matchExpressions:
             - key: kubernetes.io/arch
               operator: In
-              values:
-                - amd64
+              values: [amd64]
   tolerations:
-    - key: "dedicated"
-      operator: "Equal"
-      value: "spice"
-      effect: "NoSchedule"
+    - key: dedicated
+      operator: Equal
+      value: spice
+      effect: NoSchedule
   terminationGracePeriodSeconds: 30
 ```
 
 ## Crashloop Protection
 
-The operator monitors pods for repeated failures. When a `SpicepodSet` accumulates more dead pod observations than the configured threshold (default: 10), the operator automatically pauses the workload by setting replicas to 0.
+The operator monitors pods for repeated failures. When a `SpicepodSet` accumulates more dead pod observations than the threshold (default: `10`), the operator pauses the workload (`replicas → 0`) and records a `pauseReason` of `CrashLooping` in status. Configure via the operator CLI flag `--pause-crashlooping-pods-threshold` (`0` disables).
 
-Configure the threshold via the operator CLI flag `--pause-crashlooping-pods-threshold`.
+## Status
+
+Useful fields on `status`:
+
+| Field                             | Description                                                                                  |
+| --------------------------------- | -------------------------------------------------------------------------------------------- |
+| `replicas`                        | Formatted replica state for `kubectl` display, e.g. `2/5`.                                   |
+| `readyReplicas` / `totalReplicas` | Numeric replica counts.                                                                      |
+| `role`                            | `<none>`, `scheduler`, or `executor`.                                                        |
+| `pauseReason`                     | Set when paused (e.g. `CrashLooping`).                                                       |
+| `activeVersion`                   | Spec SHA of the version currently receiving traffic (instant rollback).                      |
+| `standbyVersion`                  | Spec SHA of the standby retained for instant rollback.                                       |
+| `standbyExpiresAt`                | Epoch seconds when the standby pods will be reclaimed.                                       |
+| `conditions`                      | Standard Kubernetes `Condition`s describing reconciliation state.                            |
+
+```bash
+kubectl get spicepodset
+# NAME          READY   ROLE     AGE   LAST UPDATED
+# my-spicepod   3/3     <none>   2d    1m
+```
 
 ## Monitoring
 
-Enable telemetry properties passed to the Spice runtime:
+Telemetry properties passed to the Spice runtime are configured at the operator level (Helm values), not on the `SpicepodSet`:
 
 ```yaml
 # Helm values for the operator

--- a/enterprise/production/README.md
+++ b/enterprise/production/README.md
@@ -38,6 +38,8 @@ Use this checklist as the definitive sign-off list before promoting a Spice.ai E
 - [ ] Local NVMe-backed nodes (AWS `i4i` / `m6id` / `c7gd` / `r7gd`, Azure `Lsv3` / `Ddsv5`, GCP `*-lssd`) for [accelerations](https://spiceai.org/docs/components/data-accelerators).
 - [ ] Backing PVC class is `io2` Block Express (AWS) or Premium SSD v2 (Azure) when shared / replica-attachable persistence is required.
 - [ ] S3-compatible object store provisioned for `SpicepodCluster` shared state; bucket versioning and lifecycle policies are enabled.
+- [ ] Object store backing `runtime.scheduler.state_location` supports conditional writes (ETag / `If-Match`) — required for multi-active correctness.
+- [ ] Every accelerated dataset and view targeted at `SpicepodCluster` declares `acceleration.partition_by`. See [Distributed Query → Partitioning](../features/distributed-query.md#partitioning-sharding-and-partition-aware-queries).
 - [ ] Acceleration sizing has been validated against expected dataset growth for the next 12 months. See [Storage](storage.md).
 
 ### Observability

--- a/enterprise/production/high-availability.md
+++ b/enterprise/production/high-availability.md
@@ -5,7 +5,7 @@ icon: arrows-split-up-and-left
 
 # High Availability
 
-Production Spice.ai Enterprise deployments are built on three HA primitives: **multiple replicas**, **multi-zone scheduling**, and **active-active distributed query**. This page documents the supported topologies and how to configure them.
+Production Spice.ai Enterprise deployments are built on three HA primitives: **multiple replicas**, **multi-zone scheduling**, and **multi-active distributed query**. This page documents the supported topologies and how to configure them.
 
 ## Topology decision tree
 
@@ -31,7 +31,7 @@ Production Spice.ai Enterprise deployments are built on three HA primitives: **m
 | `SpicepodSet` `replicas: 1` | Edge / sidecar deployments where availability is bounded by the parent service.                   | Pod restart on failure; `PodDisruptionBudget` is not applicable.    |
 | `SpicepodSet` `replicas >= 2` (stateless) | Stateless query routing or in-memory accelerations.                                | Multiple replicas behind a load balancer with health-checked routing. |
 | `SpicepodSet` `replicas >= 2` (stateful)  | File-based accelerations that benefit from local replicas.                         | Per-replica `StatefulSet`s with PVCs; ordered or parallel rollout.  |
-| `SpicepodCluster`           | Distributed analytical query, shared accelerations, multi-tenant deployments.                     | Active-active schedulers + executors over object-store-backed state. |
+| `SpicepodCluster`           | Distributed analytical query, shared accelerations, multi-tenant deployments.                     | Multi-active schedulers + executors over object-store-backed state. |
 
 ## Multi-zone scheduling
 
@@ -132,9 +132,9 @@ service:
       timeoutSeconds: 600
 ```
 
-## Active-active distributed query
+## Multi-active distributed query
 
-`SpicepodCluster` runs multiple schedulers in active-active mode with shared state in an object store. Failover is automatic: executors re-register with surviving schedulers via the cluster's known-scheduler list, and in-flight stages are retried by the surviving schedulers without restarting the query.
+`SpicepodCluster` runs multiple schedulers in multi-active mode with shared state in an object store. Failover is automatic: executors re-register with surviving schedulers via the cluster's known-scheduler list, and in-flight stages are retried by the surviving schedulers without restarting the query.
 
 See the [Distributed Query](../features/distributed-query.md) feature documentation for the underlying mechanics.
 

--- a/enterprise/production/security.md
+++ b/enterprise/production/security.md
@@ -123,6 +123,8 @@ Production deployments must authenticate every external request. Spice.ai suppor
 
 The runtime exposes the authenticated principal in SQL via the [identity functions](../features/authentication.md#identity-sql-functions): `current_principal()`, `current_principal_subject()`, `current_principal_email()`, `current_principal_groups()`. Use these in row-level filters to enforce per-user authorization.
 
+For coarse-grained allow/deny decisions across datasets, models, tools, and endpoints, configure [Cedar-based authorization policy](../features/policy.md) under `runtime.authorization`.
+
 {% hint style="warning" %}
 Never expose the runtime externally without authentication. The default Helm chart configuration permits all callers \u2014 always set `auth.enabled: true` and configure at least one provider for production.
 {% endhint %}
@@ -176,6 +178,7 @@ If running multiple Spice Operators in a single cluster (for multi-tenant isolat
 - [ ] OIDC or API key authentication enabled and tested.
 - [ ] Secrets sourced from a secret store, not `values.yaml`.
 - [ ] Identity SQL functions used for row-level authorization where applicable.
+- [ ] [Cedar authorization policy](../features/policy.md) is enabled with `default: deny` and an audited admin allow rule.
 - [ ] mTLS enabled on every `SpicepodCluster`; certificate expiry alert wired.
 - [ ] Audit logs forwarded to SIEM with 90-day retention.
 - [ ] Operator RBAC reviewed; namespace-scoped operators for multi-tenant clusters.


### PR DESCRIPTION
## Summary

Aligns existing Enterprise documentation with the new [Distributed Query](enterprise/features/distributed-query.md) reference (PR #100):

- [enterprise/features/mtls.md](enterprise/features/mtls.md) — Replace fictitious `GetCatalog` / `GetFunctions` RPCs with the real internal cluster surface (`GetAppDefinition`, `ExpandSecret`, `GetSchedulers`, `AllocateInitialPartitions`, `ControlStream`, `GetTaskHistory`, `GetMetrics`).
- [enterprise/features/functions.md](enterprise/features/functions.md) — Correct UDF distribution attribution: executors load UDFs as part of the `GetAppDefinition` bootstrap, not via a non-existent `GetFunctions` Flight endpoint.
- [enterprise/kubernetes/spicepodcluster.md](enterprise/kubernetes/spicepodcluster.md) — Expand internal-port description with the full RPC surface and link to the new feature doc.
- [enterprise/production/README.md](enterprise/production/README.md) — Add two checklist items: object-store conditional-write requirement for `state_location`, and the `partition_by` requirement for accelerated tables/views in cluster mode.

## Validation

- `git diff --check`
- No new doc-lint errors.