### PR TITLE
docs(enterprise): document Cedar row filters & column masks; correct authn/authz drift

### DIFF
--- a/enterprise/features/authentication.md
+++ b/enterprise/features/authentication.md
@@ -52,7 +52,7 @@ JWKS keys are refreshed every 5 minutes.
 
 ## API Keys
 
-Authenticate requests using static API keys with `ReadOnly` or `ReadWrite` permission levels.
+Authenticate requests using static API keys with `ReadOnly` or `ReadWrite` permission levels. Each key is a string; an optional `:ro` or `:rw` suffix sets its permission level.
 
 ```yaml
 runtime:
@@ -60,22 +60,18 @@ runtime:
     api_key:
       enabled: true
       keys:
-        - ReadOnly:
-            key: ${secrets:ro_api_key}
-        - ReadWrite:
-            key: ${secrets:rw_api_key}
+        - ${secrets:ro_api_key}:ro    # read-only
+        - ${secrets:rw_api_key}:rw    # read-write
 ```
 
 ### Permission Levels
 
-| Level       | Description                                  |
-| ----------- | -------------------------------------------- |
-| `ReadOnly`  | Can execute queries and read data            |
-| `ReadWrite` | Full access including DDL and DML operations |
+| Suffix | Level       | Description                                  |
+| ------ | ----------- | -------------------------------------------- |
+| `:ro`  | `ReadOnly`  | Can execute queries and read data            |
+| `:rw`  | `ReadWrite` | Full access including DDL and DML operations |
 
-### String Shorthand
-
-For convenience, keys can be specified as strings (defaults to `ReadWrite`):
+A key with no suffix defaults to `ReadOnly`:
 
 ```yaml
 runtime:
@@ -83,7 +79,7 @@ runtime:
     api_key:
       enabled: true
       keys:
-        - ${secrets:api_key}
+        - ${secrets:api_key}    # ReadOnly
 ```
 
 ## Combined Authentication
@@ -101,8 +97,7 @@ runtime:
     api_key:
       enabled: true
       keys:
-        - ReadOnly:
-            key: ${secrets:ro_api_key}
+        - ${secrets:ro_api_key}:ro
 ```
 
 ## Protocol-Specific Authentication
@@ -117,12 +112,12 @@ runtime:
 
 When authentication is enabled, the following SQL functions return information about the authenticated user:
 
-| Function                | Description                                                          |
-| ----------------------- | -------------------------------------------------------------------- |
-| `current_user_id()`     | Returns the user ID from the JWT `user_id` claim or API key identity |
-| `current_org_id()`      | Returns the organization ID from the JWT `org_id` claim              |
-| `current_role()`        | Returns the role of the authenticated user                           |
-| `session_property(key)` | Returns a session property by key                                    |
+| Function                          | Description                                                          |
+| --------------------------------- | -------------------------------------------------------------------- |
+| `current_user_id()`               | Returns the user ID from the JWT `user_id` claim or API key identity |
+| `current_org_id()`                | Returns the organization ID from the JWT `org_id` claim              |
+| `current_user_has_role('<role>')` | Returns `true` if the authenticated user has the given role          |
+| `session_property('<key>')`       | Returns a session property by key                                    |
 
 These functions enable row-level security and tenant-scoped queries:
 

--- a/enterprise/features/policy.md
+++ b/enterprise/features/policy.md
@@ -20,7 +20,7 @@ Policy evaluation is the standard Cedar `(principal, action, resource, context)`
 | Entity            | Description                                                                 | Notable attributes                       |
 | ----------------- | --------------------------------------------------------------------------- | ---------------------------------------- |
 | `Spice::User`     | An authenticated principal (OIDC subject, API key identity, …). `in [Role]` | `org_id`                                 |
-| `Spice::Role`     | A role or group the user belongs to (mapped from OIDC groups / API key tags) | —                                        |
+| `Spice::Role`     | A role the user belongs to. For OIDC principals, sourced from the configured role/group claims; for API-key principals, the key's `read` or `read_write` permission level | —                                        |
 | `Spice::Dataset`  | A registered dataset (table) in the runtime                                 | `catalog`, `schema`                      |
 | `Spice::Model`    | An LLM model available for inference                                        | —                                        |
 | `Spice::Tool`     | A tool (built-in or MCP) available for execution                            | —                                        |
@@ -30,7 +30,8 @@ Policy evaluation is the standard Cedar `(principal, action, resource, context)`
 
 | Action                                                 | Applies to        | Description                              |
 | ------------------------------------------------------ | ----------------- | ---------------------------------------- |
-| `Spice::Action::"query"`                               | `Spice::Dataset`  | `SELECT` and read paths.                 |
+| `Spice::Action::"query"`                               | `Spice::Dataset`  | `SELECT` / scan of a dataset.            |
+| `Spice::Action::"read"`                                | `Spice::Dataset`  | Reading a dataset's contents. Carries the fine-grained **row filter** and **column mask** annotations (see [Row Filters and Column Masks](#row-filters-and-column-masks)). A `read` permit also implicitly authorizes `query`. |
 | `Spice::Action::"insert"`                              | `Spice::Dataset`  | `INSERT` write path.                     |
 | `Spice::Action::"update"`                              | `Spice::Dataset`  | `UPDATE` write path.                     |
 | `Spice::Action::"delete"`                              | `Spice::Dataset`  | `DELETE` write path.                     |
@@ -49,8 +50,9 @@ Policies are configured under `runtime.authorization` in `spicepod.yaml`. Authen
 runtime:
   auth:
     oidc:
-      issuer: https://auth.example.com/
-      audience: spice-runtime
+      issuer_url: https://auth.example.com/
+      audience:
+        - spice-runtime
 
   authorization:
     enabled: true              # default: true
@@ -137,7 +139,9 @@ forbid(
 unless { principal in Spice::Role::"sales-ops" };
 ```
 
-### Block PII columns from non-privileged roles
+### Block a PII schema from non-privileged roles
+
+To mask individual columns rather than block access entirely, use [column masks](#row-filters-and-column-masks).
 
 ```cedar
 forbid(
@@ -183,24 +187,77 @@ unless { principal in Spice::Role::"engineer" };
 
 Policy reloads are **atomic**: in-flight requests complete against the previous policy set, and subsequent requests evaluate against the new set. Empty policy fetches do not silently disable enforcement — combined with `default: deny`, an empty set denies everything.
 
-## Combining Policy with Identity SQL Functions
+## Row Filters and Column Masks
 
-Cedar handles coarse-grained allow/deny decisions across actions and resources. For **row-level** filtering, combine policy with the [identity SQL functions](authentication.md#identity-sql-functions) in dataset views or `WHERE` clauses:
+Beyond coarse allow/deny, policies enforce **fine-grained access** — row-level filtering and column-level masking — on the `read` action. The runtime compiles these from Cedar **policy annotations** into SQL that is applied to the table scan, so filtered rows and masked values are never materialized for the request: they are enforced before any downstream operator (or the client) observes them.
 
-```yaml
-views:
-  - name: my_orders
-    sql: |
-      SELECT *
-      FROM sales.orders
-      WHERE owner_email = current_principal_email()
-        OR 'sales-ops' = ANY(current_principal_groups())
+Annotations attach to a `permit` policy for `Spice::Action::"read"`. A `read` permit also implicitly authorizes `query`, so a single `read` policy can grant masked, row-filtered access in one rule.
+
+### Annotations
+
+| Annotation                            | Effect                                                                                                              |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `@row_filter("<sql predicate>")`      | Adds a SQL boolean predicate as a row filter. May be repeated with a suffix (e.g. `@row_filter_region`); multiple filters are AND-combined. |
+| `@mask_<column>("<sql expr>")`        | Replaces `<column>` with the SQL scalar expression.                                                                 |
+| `@column_mask_<column>("<sql expr>")` | Equivalent to `@mask_<column>`.                                                                                     |
+| `@column_mask("<column>=<sql expr>")` | Equivalent, with the column named in the annotation value.                                                          |
+| `@mask_tag_<tag>("<sql expr>")`       | Replaces every column carrying `<tag>` (see [Tagging columns](#tagging-columns)).                                   |
+| `@column_mask_tag("<tag>=<sql expr>")`| Equivalent, with the tag named in the annotation value.                                                             |
+| `@target_table("<dataset>")`          | Scopes the annotations to a single dataset when the policy matches more than one.                                   |
+
+Row filters and mask expressions are evaluated with the request's identity, so they can reference the [identity SQL functions](authentication.md#identity-sql-functions) (`current_user_id()`, `current_org_id()`, `current_user_has_role('...')`) for per-user or per-tenant access.
+
+### Example
+
+```cedar
+// Physicians: full access to patients in their own organization.
+@id("physician_read")
+@row_filter("org = current_org_id()")
+permit(
+  principal in Spice::Role::"physician",
+  action == Spice::Action::"read",
+  resource == Spice::Dataset::"patients"
+);
+
+// Analysts: same org scoping, but SSN and any PHI-tagged column are masked.
+@id("analyst_read")
+@row_filter("org = current_org_id()")
+@mask_ssn("'XXX-XX-XXXX'")
+@mask_tag_phi("'REDACTED'")
+permit(
+  principal in Spice::Role::"analyst",
+  action == Spice::Action::"read",
+  resource == Spice::Dataset::"patients"
+);
 ```
 
-A typical layered model:
+With these policies, an analyst running `SELECT * FROM patients` sees only their organization's rows with `ssn` and any PHI-tagged column replaced, while a physician sees their organization's rows unmasked — from the same query.
 
-1. Cedar policy decides whether the principal may `query` a dataset at all.
-2. SQL views with identity functions filter the rows the principal may see.
+### Tagging columns
+
+Tag-based masks (`@mask_tag_*` / `@column_mask_tag`) target columns by the dataset's column metadata:
+
+```yaml
+datasets:
+  - from: postgres:patients
+    name: patients
+    columns:
+      - name: diagnosis
+        metadata:
+          tags:
+            - phi
+```
+
+### Rules
+
+- Fine-grained annotations are honored only on `permit` policies. Attaching one to a `forbid` is a load-time error.
+- A row filter must evaluate to a Boolean; a column mask expression must return the column's data type. Type mismatches **fail closed** — the query errors rather than returning unmasked data.
+- If two matching policies define conflicting masks for the same column or tag, policy load fails.
+- To deny access outright, use a `forbid` on `read`/`query` rather than a mask.
+
+{% hint style="info" %}
+The [identity SQL functions](authentication.md#identity-sql-functions) are also available directly in dataset views and ad-hoc `WHERE` clauses for row-level logic outside of policy enforcement.
+{% endhint %}
 
 ## Distributed Cluster Behavior
 

--- a/enterprise/production/security.md
+++ b/enterprise/production/security.md
@@ -121,9 +121,9 @@ Production deployments must authenticate every external request. Spice.ai suppor
 - [**API keys**](../features/authentication.md#api-keys) \u2014 hashed keys configured in the runtime, suitable for service-to-service calls.
 - **Combined** \u2014 OIDC for human users, API keys for service callers, both checked on every request.
 
-The runtime exposes the authenticated principal in SQL via the [identity functions](../features/authentication.md#identity-sql-functions): `current_principal()`, `current_principal_subject()`, `current_principal_email()`, `current_principal_groups()`. Use these in row-level filters to enforce per-user authorization.
+The runtime exposes the authenticated principal in SQL via the [identity functions](../features/authentication.md#identity-sql-functions): `current_user_id()`, `current_org_id()`, `current_user_has_role('<role>')`, and `session_property('<key>')`. Use these in row filters and column masks to enforce per-user authorization.
 
-For coarse-grained allow/deny decisions across datasets, models, tools, and endpoints, configure [Cedar-based authorization policy](../features/policy.md) under `runtime.authorization`.
+For allow/deny decisions across datasets, models, tools, and endpoints — plus fine-grained [row filters and column masks](../features/policy.md#row-filters-and-column-masks) — configure [Cedar-based authorization policy](../features/policy.md) under `runtime.authorization`.
 
 {% hint style="warning" %}
 Never expose the runtime externally without authentication. The default Helm chart configuration permits all callers \u2014 always set `auth.enabled: true` and configure at least one provider for production.


### PR DESCRIPTION
## Summary

Documents the native Cedar **row filters** and **column masks** on the `read` action, and corrects drift found while auditing the authn/authz pages against the runtime.

### Authorization Policy (`enterprise/features/policy.md`)
- New **Row Filters and Column Masks** section: the `@row_filter`, `@mask_<col>` / `@column_mask*`, `@mask_tag_<tag>` / `@column_mask_tag`, and `@target_table` annotations; the `read`-implies-`query` behavior; column tagging; and the load-time/type rules (permit-only, Boolean filters, type-matched masks that fail closed, conflicting-mask errors). This replaces the prior "row-level filtering requires SQL views" guidance, which no longer reflects the runtime.
- Added the `read` action to the actions table.
- Fixed the OIDC config example (`issuer` → `issuer_url`, list `audience`) and the `Spice::Role` sourcing note.

### Authentication (`enterprise/features/authentication.md`)
- Identity SQL functions: `current_user_has_role('<role>')` replaces the non-existent `current_role()`.
- API keys: keys are strings with an optional `:ro` / `:rw` suffix (no suffix → `ReadOnly`). The map form (`- ReadOnly: { key: }`) and the "string shorthand defaults to ReadWrite" note were both incorrect.

### Security (`enterprise/production/security.md`)
- Replaced the non-existent `current_principal*` identity functions with the real ones and linked the new row-filter/column-mask section.

All annotation keys, function names, the `read` action, and config field names were verified against the runtime source.
