### PR TITLE
docs(cloud): dedicated clusters via the Management API

### DIFF
--- a/cloud/api/SUMMARY.md
+++ b/cloud/api/SUMMARY.md
@@ -26,4 +26,5 @@
           kind: openapi
           spec: spiceai-management-api
     ```
+* [Dedicated Clusters](management/dedicated-clusters.md)
 * [Terraform Provider](management-api/terraform.md)

--- a/cloud/api/management/README.md
+++ b/cloud/api/management/README.md
@@ -233,11 +233,13 @@ curl -X POST https://api.spice.ai/v1/apps \
   -H "Content-Type: application/json" \
   -d '{
     "name": "my-app",
-    "cname": "us-west-2-prod-aws-data",
+    "region": "us-west-2",
     "description": "My Spice app",
     "visibility": "private"
   }'
 ```
+
+Organizations with a [dedicated cluster](dedicated-clusters.md) can pass `cluster_name` in place of `region` to create the app on their dedicated infrastructure.
 
 ### Create a deployment
 

--- a/cloud/api/management/dedicated-clusters.md
+++ b/cloud/api/management/dedicated-clusters.md
@@ -1,0 +1,116 @@
+---
+description: Create and manage apps on a dedicated, single-tenant cluster
+icon: server
+---
+
+# Dedicated Clusters
+
+Organizations on an enterprise plan can have one or more **dedicated clusters**: Spice-managed, single-tenant infrastructure reserved exclusively for the organization, with its own isolated network and dedicated query endpoints. Apps assigned to a dedicated cluster run only alongside other apps from your organization — never on shared infrastructure.
+
+Dedicated clusters are provisioned by Spice.ai. Contact [support](https://spice.ai/support) to request one. Once provisioned and registered to your organization, it is available to the Management API and in the Portal's app-creation region picker.
+
+## List your organization's clusters
+
+`GET /v1/clusters` returns the dedicated clusters registered to the organization bound to your access token. Requires the `apps:read` scope.
+
+```bash
+curl -H "Authorization: Bearer <token>" \
+  https://api.spice.ai/v1/clusters
+```
+
+```json
+{
+  "clusters": [
+    {
+      "cluster_name": "acme-prod",
+      "region": "us-west-2",
+      "cloud_provider": "aws",
+      "endpoint": "acme-prod-us-west-2-prod-data.spiceai.io",
+      "created_at": "2026-06-11T00:00:00Z",
+      "updated_at": "2026-06-11T00:00:00Z"
+    }
+  ]
+}
+```
+
+`cluster_name` is the cluster's identifier — use it when creating or reassigning apps. `endpoint` is the cluster's dedicated data-plane host (see [Querying apps on a dedicated cluster](#querying-apps-on-a-dedicated-cluster)).
+
+## Create an app on a dedicated cluster
+
+Pass `cluster_name` instead of `region` when creating an app. Provide exactly one of the two — the app's region is derived from the cluster. Requires the `apps:write` scope.
+
+```bash
+curl -X POST https://api.spice.ai/v1/apps \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "my-app",
+    "cluster_name": "acme-prod",
+    "description": "My app on our dedicated cluster"
+  }'
+```
+
+The response includes the resolved cluster assignment:
+
+```json
+{
+  "id": 123,
+  "name": "my-app",
+  "cluster_name": "acme-prod",
+  "endpoint": "https://acme-prod-us-west-2-prod-data.spiceai.io",
+  "...": "..."
+}
+```
+
+Apps created without `cluster_name` deploy to the shared regional infrastructure as usual; `cluster_name: null` is equivalent to omitting it.
+
+{% hint style="info" %}
+If `region` is also provided it must match the cluster's region; the deprecated `cname` field cannot be combined with `cluster_name`.
+{% endhint %}
+
+### Errors
+
+| Status | Cause |
+| ------ | ----- |
+| `400` `Cluster '<name>' not found` | The cluster does not exist or is not registered to your organization |
+| `400` `region '<r>' does not match cluster region '<r2>'` | An explicit `region` was provided that differs from the cluster's region |
+| `400` `'cname' (deprecated) cannot be combined with 'cluster_name'` | Provide one region source only |
+
+## Move an existing app to a dedicated cluster
+
+`PATCH /v1/apps/{appId}` with `cluster_name` reassigns the app. Subsequent deployments land on the dedicated cluster, and the app's endpoints change to the cluster's dedicated hosts.
+
+```bash
+curl -X PATCH https://api.spice.ai/v1/apps/123 \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"cluster_name": "acme-prod"}'
+```
+
+{% hint style="warning" %}
+Reassigning an app changes its data and Flight endpoints. Update any clients that pin the shared regional hostnames, then create a new [deployment](README.md#create-a-deployment) so the app's runtime is placed on the cluster.
+{% endhint %}
+
+## Querying apps on a dedicated cluster
+
+Apps on a dedicated cluster are served from the cluster's own endpoints rather than the shared regional ones:
+
+| API | Endpoint |
+| --- | -------- |
+| HTTP (SQL, search, LLM) | `https://{cluster_name}-{region}-prod-data.spiceai.io` |
+| Apache Arrow Flight | `grpc+tls://{cluster_name}-{region}-prod-flight.spiceai.io:443` |
+
+The HTTP endpoint is returned as `endpoint` on the app; the Flight host is the same hostname with `-data` replaced by `-flight`. Authentication is unchanged — use the app's [API key](../../portal/apps/api-keys.md) or your platform credentials exactly as on shared infrastructure.
+
+When using the [SDKs](../../../sdks/), pass the dedicated endpoints in place of the `data.spiceai.io` / `flight.spiceai.io` defaults. For example with the [Python SDK](../../../sdks/python-sdk/):
+
+```python
+from spicepy import Client
+
+client = Client(
+    api_key="<app-api-key>",
+    url="grpc+tls://acme-prod-us-west-2-prod-flight.spiceai.io:443",
+)
+```
+
+Everything else — deployments, secrets, API keys, spicepod configuration — works identically to apps on shared infrastructure. See the [Management APIs](README.md) reference for the full endpoint documentation.

--- a/cloud/api/management/dedicated-clusters.md
+++ b/cloud/api/management/dedicated-clusters.md
@@ -7,8 +7,6 @@ icon: server
 
 Organizations on an enterprise plan can have one or more **dedicated clusters**: Spice-managed, single-tenant infrastructure where your apps run only alongside other apps from your organization — never on shared public infrastructure. Each cluster has its own `cluster_name`, isolated network, and query endpoints.
 
-Clusters can **share underlying infrastructure** with other clusters in your organization — for example an `acme-prod-sandbox` and an `acme-prod-staging` cluster running on the same hardware — or be **completely isolated** on their own dedicated infrastructure. Either way they are separate, independently-addressable clusters; the `infra_cluster_name` field tells you which clusters share infrastructure.
-
 Dedicated clusters are provisioned by Spice.ai. Contact [support](https://spice.ai/support) to request one. Once provisioned and registered to your organization, your clusters are available to the Management API and in the Portal's app-creation picker.
 
 ## List your clusters
@@ -25,19 +23,10 @@ curl -H "Authorization: Bearer <token>" \
   "clusters": [
     {
       "cluster_name": "acme-prod-sandbox",
-      "infra_cluster_name": "acme-prod",
       "region": "us-west-2",
       "cloud_provider": "aws",
       "endpoint": "private-acme-prod-sandbox-us-west-2-prod-data.spiceai.io",
-      "created_at": "2026-06-11T00:00:00Z",
-      "updated_at": "2026-06-11T00:00:00Z"
-    },
-    {
-      "cluster_name": "acme-prod-staging",
-      "infra_cluster_name": "acme-prod",
-      "region": "us-west-2",
-      "cloud_provider": "aws",
-      "endpoint": "private-acme-prod-staging-us-west-2-prod-data.spiceai.io",
+      "public_endpoint": "acme-prod-us-west-2-prod-data.spiceai.io",
       "created_at": "2026-06-11T00:00:00Z",
       "updated_at": "2026-06-11T00:00:00Z"
     }
@@ -46,8 +35,8 @@ curl -H "Authorization: Bearer <token>" \
 ```
 
 - **`cluster_name`** — the cluster's identifier. Use it when creating or reassigning apps.
-- **`infra_cluster_name`** — the underlying infrastructure the cluster runs on. Clusters that share an `infra_cluster_name` run on the same hardware (while staying isolated from each other); a value unique to one cluster means it's fully isolated.
-- **`endpoint`** — the cluster's **private** data-plane host (see [Querying apps](#querying-apps-on-a-dedicated-cluster)).
+- **`endpoint`** — the cluster's **private** data-plane host, reachable only over your private connectivity (see [Querying apps](#querying-apps-on-a-dedicated-cluster)).
+- **`public_endpoint`** — the cluster's **public** data-plane host, always reachable over the internet.
 
 ## Create an app on a dedicated cluster
 
@@ -87,7 +76,7 @@ If `region` is also provided it must match the cluster's region; the deprecated 
 | Status | Cause |
 | ------ | ----- |
 | `400` `Cluster '<name>' not found` | The cluster does not exist or is not registered to your organization |
-| `400` | The name you passed is shared infrastructure (an `infra_cluster_name`), not a deployable cluster — use a `cluster_name` from `GET /v1/clusters` |
+| `400` `'<name>' is not a deployable cluster` | The name isn't a cluster you can deploy to — pass a `cluster_name` from `GET /v1/clusters` |
 | `400` `region '<r>' does not match cluster region '<r2>'` | An explicit `region` was provided that differs from the cluster's region |
 | `400` `'cname' (deprecated) cannot be combined with 'cluster_name'` | Provide one region source only |
 
@@ -108,16 +97,14 @@ Reassigning an app changes its data and Flight endpoints. Update any clients tha
 
 ## Querying apps on a dedicated cluster
 
-Apps on a dedicated cluster can be reached two ways — a **private** endpoint unique to the cluster, and a **public** endpoint on the cluster's underlying infrastructure. Both route to the same app; authentication is unchanged (use the app's [API key](../../portal/apps/api-keys.md) or your platform credentials exactly as on shared infrastructure).
+`GET /v1/clusters` returns two data-plane hosts for each cluster — use whichever fits your connectivity:
 
-| | HTTP (SQL, search, LLM) | Apache Arrow Flight | Availability |
-| --- | --- | --- | --- |
-| **Private** (this cluster) | `https://private-{cluster_name}-{region}-prod-data.spiceai.io` | `grpc+tls://private-{cluster_name}-{region}-prod-flight.spiceai.io:443` | Only when **VPC peering / private connectivity** is enabled — these hosts resolve to a private address inside the cluster's network |
-| **Public** (shared infrastructure) | `https://{infra_cluster_name}-{region}-prod-data.spiceai.io` | `grpc+tls://{infra_cluster_name}-{region}-prod-flight.spiceai.io:443` | Always available over the public internet |
+- **`endpoint`** — the cluster's **private** host (`private-…`). Reachable only when **VPC peering / private connectivity** is enabled for your cluster.
+- **`public_endpoint`** — always reachable over the public internet.
 
-`GET /v1/clusters` and the app's `endpoint` field return the **private** host. If your cluster doesn't have private connectivity set up, use the **public** host instead — built from `infra_cluster_name` (the Flight host is the same hostname with `-data` replaced by `-flight`).
+Both serve the same APIs (SQL, search, and LLM over HTTP, plus Apache Arrow Flight), and authentication is unchanged — use the app's [API key](../../portal/apps/api-keys.md) or your platform credentials exactly as on shared infrastructure. For Apache Arrow Flight, take either host, replace `-data` with `-flight`, and connect over `grpc+tls://<host>:443`.
 
-When using the [SDKs](../../../sdks/), pass the chosen endpoint in place of the `data.spiceai.io` / `flight.spiceai.io` defaults. For example with the [Python SDK](../../../sdks/python-sdk/), using the private Flight endpoint over VPC peering:
+When using the [SDKs](../../../sdks/), pass the chosen host in place of the `data.spiceai.io` / `flight.spiceai.io` defaults. For example with the [Python SDK](../../../sdks/python-sdk/), over the private Flight endpoint (VPC peering):
 
 ```python
 from spicepy import Client

--- a/cloud/api/management/dedicated-clusters.md
+++ b/cloud/api/management/dedicated-clusters.md
@@ -7,11 +7,13 @@ icon: server
 
 Organizations on an enterprise plan can have one or more **dedicated clusters**: Spice-managed, single-tenant infrastructure reserved exclusively for the organization, with its own isolated network and dedicated query endpoints. Apps assigned to a dedicated cluster run only alongside other apps from your organization — never on shared infrastructure.
 
-Dedicated clusters are provisioned by Spice.ai. Contact [support](https://spice.ai/support) to request one. Once provisioned and registered to your organization, it is available to the Management API and in the Portal's app-creation region picker.
+A dedicated cluster exposes one or more **deployment targets**. Each target has its own `cluster_name` and its own private endpoint, so you can keep separate environments (for example `acme-prod-sandbox` and `acme-prod-staging`) isolated on the same dedicated hardware. You assign an app to a target by its `cluster_name`.
 
-## List your organization's clusters
+Dedicated clusters are provisioned by Spice.ai. Contact [support](https://spice.ai/support) to request one. Once provisioned and registered to your organization, the deployment targets are available to the Management API and in the Portal's app-creation picker.
 
-`GET /v1/clusters` returns the dedicated clusters registered to the organization bound to your access token. Requires the `apps:read` scope.
+## List your deployment targets
+
+`GET /v1/clusters` returns the deployment targets registered to the organization bound to your access token. Requires the `apps:read` scope.
 
 ```bash
 curl -H "Authorization: Bearer <token>" \
@@ -22,10 +24,20 @@ curl -H "Authorization: Bearer <token>" \
 {
   "clusters": [
     {
-      "cluster_name": "acme-prod",
+      "cluster_name": "acme-prod-sandbox",
+      "infra_cluster_name": "acme-prod",
       "region": "us-west-2",
       "cloud_provider": "aws",
-      "endpoint": "acme-prod-us-west-2-prod-data.spiceai.io",
+      "endpoint": "private-acme-prod-sandbox-us-west-2-prod-data.spiceai.io",
+      "created_at": "2026-06-11T00:00:00Z",
+      "updated_at": "2026-06-11T00:00:00Z"
+    },
+    {
+      "cluster_name": "acme-prod-staging",
+      "infra_cluster_name": "acme-prod",
+      "region": "us-west-2",
+      "cloud_provider": "aws",
+      "endpoint": "private-acme-prod-staging-us-west-2-prod-data.spiceai.io",
       "created_at": "2026-06-11T00:00:00Z",
       "updated_at": "2026-06-11T00:00:00Z"
     }
@@ -33,11 +45,13 @@ curl -H "Authorization: Bearer <token>" \
 }
 ```
 
-`cluster_name` is the cluster's identifier — use it when creating or reassigning apps. `endpoint` is the cluster's dedicated data-plane host (see [Querying apps on a dedicated cluster](#querying-apps-on-a-dedicated-cluster)).
+- **`cluster_name`** — the deployment target's identifier. Use it when creating or reassigning apps.
+- **`infra_cluster_name`** — the dedicated cluster the target runs on (read-only). Targets that share an `infra_cluster_name` are isolated environments on the same cluster.
+- **`endpoint`** — the target's **private** data-plane host (see [Querying apps](#querying-apps-on-a-dedicated-cluster)).
 
-## Create an app on a dedicated cluster
+## Create an app on a deployment target
 
-Pass `cluster_name` instead of `region` when creating an app. Provide exactly one of the two — the app's region is derived from the cluster. Requires the `apps:write` scope.
+Pass `cluster_name` instead of `region` when creating an app — set it to a `cluster_name` returned by `GET /v1/clusters`. Provide exactly one of the two; the app's region is derived from the target. Requires the `apps:write` scope.
 
 ```bash
 curl -X POST https://api.spice.ai/v1/apps \
@@ -45,19 +59,19 @@ curl -X POST https://api.spice.ai/v1/apps \
   -H "Content-Type: application/json" \
   -d '{
     "name": "my-app",
-    "cluster_name": "acme-prod",
+    "cluster_name": "acme-prod-sandbox",
     "description": "My app on our dedicated cluster"
   }'
 ```
 
-The response includes the resolved cluster assignment:
+The response includes the resolved assignment (`endpoint` is the target's private host):
 
 ```json
 {
   "id": 123,
   "name": "my-app",
-  "cluster_name": "acme-prod",
-  "endpoint": "https://acme-prod-us-west-2-prod-data.spiceai.io",
+  "cluster_name": "acme-prod-sandbox",
+  "endpoint": "https://private-acme-prod-sandbox-us-west-2-prod-data.spiceai.io",
   "...": "..."
 }
 ```
@@ -65,51 +79,52 @@ The response includes the resolved cluster assignment:
 Apps created without `cluster_name` deploy to the shared regional infrastructure as usual; `cluster_name: null` is equivalent to omitting it.
 
 {% hint style="info" %}
-If `region` is also provided it must match the cluster's region; the deprecated `cname` field cannot be combined with `cluster_name`.
+If `region` is also provided it must match the target's region; the deprecated `cname` field cannot be combined with `cluster_name`.
 {% endhint %}
 
 ### Errors
 
 | Status | Cause |
 | ------ | ----- |
-| `400` `Cluster '<name>' not found` | The cluster does not exist or is not registered to your organization |
-| `400` `region '<r>' does not match cluster region '<r2>'` | An explicit `region` was provided that differs from the cluster's region |
+| `400` `Cluster '<name>' not found` | The target does not exist or is not registered to your organization |
+| `400` `'<name>' is a cluster, not a deployment target; assign one of its nodegroups` | You passed an `infra_cluster_name`; assign a deployment-target `cluster_name` from `GET /v1/clusters` |
+| `400` `region '<r>' does not match cluster region '<r2>'` | An explicit `region` was provided that differs from the target's region |
 | `400` `'cname' (deprecated) cannot be combined with 'cluster_name'` | Provide one region source only |
 
-## Move an existing app to a dedicated cluster
+## Move an existing app to a deployment target
 
-`PATCH /v1/apps/{appId}` with `cluster_name` reassigns the app. Subsequent deployments land on the dedicated cluster, and the app's endpoints change to the cluster's dedicated hosts.
+`PUT /v1/apps/{appId}` with `cluster_name` reassigns the app. Subsequent deployments land on the target, and the app's endpoints change to the target's hosts.
 
 ```bash
-curl -X PATCH https://api.spice.ai/v1/apps/123 \
+curl -X PUT https://api.spice.ai/v1/apps/123 \
   -H "Authorization: Bearer <token>" \
   -H "Content-Type: application/json" \
-  -d '{"cluster_name": "acme-prod"}'
+  -d '{"cluster_name": "acme-prod-sandbox"}'
 ```
 
 {% hint style="warning" %}
-Reassigning an app changes its data and Flight endpoints. Update any clients that pin the shared regional hostnames, then create a new [deployment](README.md#create-a-deployment) so the app's runtime is placed on the cluster.
+Reassigning an app changes its data and Flight endpoints. Update any clients that pin the old hostnames, then create a new [deployment](README.md#create-a-deployment) so the app's runtime is placed on the target.
 {% endhint %}
 
 ## Querying apps on a dedicated cluster
 
-Apps on a dedicated cluster are served from the cluster's own endpoints rather than the shared regional ones:
+Apps on a dedicated cluster can be reached two ways — a **private** per-target endpoint and a **public** per-cluster endpoint. Both route to the same app; authentication is unchanged (use the app's [API key](../../portal/apps/api-keys.md) or your platform credentials exactly as on shared infrastructure).
 
-| API | Endpoint |
-| --- | -------- |
-| HTTP (SQL, search, LLM) | `https://{cluster_name}-{region}-prod-data.spiceai.io` |
-| Apache Arrow Flight | `grpc+tls://{cluster_name}-{region}-prod-flight.spiceai.io:443` |
+| | HTTP (SQL, search, LLM) | Apache Arrow Flight | Availability |
+| --- | --- | --- | --- |
+| **Private** (per target) | `https://private-{cluster_name}-{region}-prod-data.spiceai.io` | `grpc+tls://private-{cluster_name}-{region}-prod-flight.spiceai.io:443` | Only when **VPC peering / private connectivity** is enabled for the cluster — these hosts resolve to a private address inside the cluster's network |
+| **Public** (per cluster) | `https://{infra_cluster_name}-{region}-prod-data.spiceai.io` | `grpc+tls://{infra_cluster_name}-{region}-prod-flight.spiceai.io:443` | Always available over the public internet |
 
-The HTTP endpoint is returned as `endpoint` on the app; the Flight host is the same hostname with `-data` replaced by `-flight`. Authentication is unchanged — use the app's [API key](../../portal/apps/api-keys.md) or your platform credentials exactly as on shared infrastructure.
+`GET /v1/clusters` and the app's `endpoint` field return the **private** host. If your cluster doesn't have private connectivity set up, use the **public** host instead — derive it from `infra_cluster_name` (the Flight host is the same hostname with `-data` replaced by `-flight`).
 
-When using the [SDKs](../../../sdks/), pass the dedicated endpoints in place of the `data.spiceai.io` / `flight.spiceai.io` defaults. For example with the [Python SDK](../../../sdks/python-sdk/):
+When using the [SDKs](../../../sdks/), pass the chosen endpoint in place of the `data.spiceai.io` / `flight.spiceai.io` defaults. For example with the [Python SDK](../../../sdks/python-sdk/), using the private Flight endpoint over VPC peering:
 
 ```python
 from spicepy import Client
 
 client = Client(
     api_key="<app-api-key>",
-    url="grpc+tls://acme-prod-us-west-2-prod-flight.spiceai.io:443",
+    url="grpc+tls://private-acme-prod-sandbox-us-west-2-prod-flight.spiceai.io:443",
 )
 ```
 

--- a/cloud/api/management/dedicated-clusters.md
+++ b/cloud/api/management/dedicated-clusters.md
@@ -5,15 +5,15 @@ icon: server
 
 # Dedicated Clusters
 
-Organizations on an enterprise plan can have one or more **dedicated clusters**: Spice-managed, single-tenant infrastructure reserved exclusively for the organization, with its own isolated network and dedicated query endpoints. Apps assigned to a dedicated cluster run only alongside other apps from your organization — never on shared infrastructure.
+Organizations on an enterprise plan can have one or more **dedicated clusters**: Spice-managed, single-tenant infrastructure where your apps run only alongside other apps from your organization — never on shared public infrastructure. Each cluster has its own `cluster_name`, isolated network, and query endpoints.
 
-A dedicated cluster exposes one or more **deployment targets**. Each target has its own `cluster_name` and its own private endpoint, so you can keep separate environments (for example `acme-prod-sandbox` and `acme-prod-staging`) isolated on the same dedicated hardware. You assign an app to a target by its `cluster_name`.
+Clusters can **share underlying infrastructure** with other clusters in your organization — for example an `acme-prod-sandbox` and an `acme-prod-staging` cluster running on the same hardware — or be **completely isolated** on their own dedicated infrastructure. Either way they are separate, independently-addressable clusters; the `infra_cluster_name` field tells you which clusters share infrastructure.
 
-Dedicated clusters are provisioned by Spice.ai. Contact [support](https://spice.ai/support) to request one. Once provisioned and registered to your organization, the deployment targets are available to the Management API and in the Portal's app-creation picker.
+Dedicated clusters are provisioned by Spice.ai. Contact [support](https://spice.ai/support) to request one. Once provisioned and registered to your organization, your clusters are available to the Management API and in the Portal's app-creation picker.
 
-## List your deployment targets
+## List your clusters
 
-`GET /v1/clusters` returns the deployment targets registered to the organization bound to your access token. Requires the `apps:read` scope.
+`GET /v1/clusters` returns the dedicated clusters registered to the organization bound to your access token. Requires the `apps:read` scope.
 
 ```bash
 curl -H "Authorization: Bearer <token>" \
@@ -45,13 +45,13 @@ curl -H "Authorization: Bearer <token>" \
 }
 ```
 
-- **`cluster_name`** — the deployment target's identifier. Use it when creating or reassigning apps.
-- **`infra_cluster_name`** — the dedicated cluster the target runs on (read-only). Targets that share an `infra_cluster_name` are isolated environments on the same cluster.
-- **`endpoint`** — the target's **private** data-plane host (see [Querying apps](#querying-apps-on-a-dedicated-cluster)).
+- **`cluster_name`** — the cluster's identifier. Use it when creating or reassigning apps.
+- **`infra_cluster_name`** — the underlying infrastructure the cluster runs on. Clusters that share an `infra_cluster_name` run on the same hardware (while staying isolated from each other); a value unique to one cluster means it's fully isolated.
+- **`endpoint`** — the cluster's **private** data-plane host (see [Querying apps](#querying-apps-on-a-dedicated-cluster)).
 
-## Create an app on a deployment target
+## Create an app on a dedicated cluster
 
-Pass `cluster_name` instead of `region` when creating an app — set it to a `cluster_name` returned by `GET /v1/clusters`. Provide exactly one of the two; the app's region is derived from the target. Requires the `apps:write` scope.
+Pass `cluster_name` instead of `region` when creating an app — set it to a `cluster_name` returned by `GET /v1/clusters`. Provide exactly one of the two; the app's region is derived from the cluster. Requires the `apps:write` scope.
 
 ```bash
 curl -X POST https://api.spice.ai/v1/apps \
@@ -64,7 +64,7 @@ curl -X POST https://api.spice.ai/v1/apps \
   }'
 ```
 
-The response includes the resolved assignment (`endpoint` is the target's private host):
+The response includes the resolved assignment (`endpoint` is the cluster's private host):
 
 ```json
 {
@@ -79,21 +79,21 @@ The response includes the resolved assignment (`endpoint` is the target's privat
 Apps created without `cluster_name` deploy to the shared regional infrastructure as usual; `cluster_name: null` is equivalent to omitting it.
 
 {% hint style="info" %}
-If `region` is also provided it must match the target's region; the deprecated `cname` field cannot be combined with `cluster_name`.
+If `region` is also provided it must match the cluster's region; the deprecated `cname` field cannot be combined with `cluster_name`.
 {% endhint %}
 
 ### Errors
 
 | Status | Cause |
 | ------ | ----- |
-| `400` `Cluster '<name>' not found` | The target does not exist or is not registered to your organization |
-| `400` `'<name>' is a cluster, not a deployment target; assign one of its nodegroups` | You passed an `infra_cluster_name`; assign a deployment-target `cluster_name` from `GET /v1/clusters` |
-| `400` `region '<r>' does not match cluster region '<r2>'` | An explicit `region` was provided that differs from the target's region |
+| `400` `Cluster '<name>' not found` | The cluster does not exist or is not registered to your organization |
+| `400` | The name you passed is shared infrastructure (an `infra_cluster_name`), not a deployable cluster — use a `cluster_name` from `GET /v1/clusters` |
+| `400` `region '<r>' does not match cluster region '<r2>'` | An explicit `region` was provided that differs from the cluster's region |
 | `400` `'cname' (deprecated) cannot be combined with 'cluster_name'` | Provide one region source only |
 
-## Move an existing app to a deployment target
+## Move an existing app to a dedicated cluster
 
-`PUT /v1/apps/{appId}` with `cluster_name` reassigns the app. Subsequent deployments land on the target, and the app's endpoints change to the target's hosts.
+`PUT /v1/apps/{appId}` with `cluster_name` reassigns the app. Subsequent deployments land on the cluster, and the app's endpoints change to the cluster's hosts.
 
 ```bash
 curl -X PUT https://api.spice.ai/v1/apps/123 \
@@ -103,19 +103,19 @@ curl -X PUT https://api.spice.ai/v1/apps/123 \
 ```
 
 {% hint style="warning" %}
-Reassigning an app changes its data and Flight endpoints. Update any clients that pin the old hostnames, then create a new [deployment](README.md#create-a-deployment) so the app's runtime is placed on the target.
+Reassigning an app changes its data and Flight endpoints. Update any clients that pin the old hostnames, then create a new [deployment](README.md#create-a-deployment) so the app's runtime is placed on the cluster.
 {% endhint %}
 
 ## Querying apps on a dedicated cluster
 
-Apps on a dedicated cluster can be reached two ways — a **private** per-target endpoint and a **public** per-cluster endpoint. Both route to the same app; authentication is unchanged (use the app's [API key](../../portal/apps/api-keys.md) or your platform credentials exactly as on shared infrastructure).
+Apps on a dedicated cluster can be reached two ways — a **private** endpoint unique to the cluster, and a **public** endpoint on the cluster's underlying infrastructure. Both route to the same app; authentication is unchanged (use the app's [API key](../../portal/apps/api-keys.md) or your platform credentials exactly as on shared infrastructure).
 
 | | HTTP (SQL, search, LLM) | Apache Arrow Flight | Availability |
 | --- | --- | --- | --- |
-| **Private** (per target) | `https://private-{cluster_name}-{region}-prod-data.spiceai.io` | `grpc+tls://private-{cluster_name}-{region}-prod-flight.spiceai.io:443` | Only when **VPC peering / private connectivity** is enabled for the cluster — these hosts resolve to a private address inside the cluster's network |
-| **Public** (per cluster) | `https://{infra_cluster_name}-{region}-prod-data.spiceai.io` | `grpc+tls://{infra_cluster_name}-{region}-prod-flight.spiceai.io:443` | Always available over the public internet |
+| **Private** (this cluster) | `https://private-{cluster_name}-{region}-prod-data.spiceai.io` | `grpc+tls://private-{cluster_name}-{region}-prod-flight.spiceai.io:443` | Only when **VPC peering / private connectivity** is enabled — these hosts resolve to a private address inside the cluster's network |
+| **Public** (shared infrastructure) | `https://{infra_cluster_name}-{region}-prod-data.spiceai.io` | `grpc+tls://{infra_cluster_name}-{region}-prod-flight.spiceai.io:443` | Always available over the public internet |
 
-`GET /v1/clusters` and the app's `endpoint` field return the **private** host. If your cluster doesn't have private connectivity set up, use the **public** host instead — derive it from `infra_cluster_name` (the Flight host is the same hostname with `-data` replaced by `-flight`).
+`GET /v1/clusters` and the app's `endpoint` field return the **private** host. If your cluster doesn't have private connectivity set up, use the **public** host instead — built from `infra_cluster_name` (the Flight host is the same hostname with `-data` replaced by `-flight`).
 
 When using the [SDKs](../../../sdks/), pass the chosen endpoint in place of the `data.spiceai.io` / `flight.spiceai.io` defaults. For example with the [Python SDK](../../../sdks/python-sdk/), using the private Flight endpoint over VPC peering:
 

--- a/cloud/api/management/dedicated-clusters.md
+++ b/cloud/api/management/dedicated-clusters.md
@@ -69,7 +69,7 @@ The response includes the resolved assignment and both endpoints:
 Apps created without `cluster_name` deploy to the shared regional infrastructure as usual; `cluster_name: null` is equivalent to omitting it.
 
 {% hint style="info" %}
-If `region` is also provided it must match the cluster's region; the deprecated `cname` field cannot be combined with `cluster_name`.
+If `region` is also provided it must match the cluster's region.
 {% endhint %}
 
 ### Errors
@@ -79,7 +79,6 @@ If `region` is also provided it must match the cluster's region; the deprecated 
 | `400` `Cluster '<name>' not found` | The cluster does not exist or is not registered to your organization |
 | `400` `'<name>' is not a deployable cluster` | The name isn't a cluster you can deploy to — pass a `cluster_name` from `GET /v1/clusters` |
 | `400` `region '<r>' does not match cluster region '<r2>'` | An explicit `region` was provided that differs from the cluster's region |
-| `400` `'cname' (deprecated) cannot be combined with 'cluster_name'` | Provide one region source only |
 
 ## Move an existing app to a dedicated cluster
 

--- a/cloud/api/management/dedicated-clusters.md
+++ b/cloud/api/management/dedicated-clusters.md
@@ -25,8 +25,8 @@ curl -H "Authorization: Bearer <token>" \
       "cluster_name": "acme-prod-sandbox",
       "region": "us-west-2",
       "cloud_provider": "aws",
-      "endpoint": "private-acme-prod-sandbox-us-west-2-prod-data.spiceai.io",
-      "public_endpoint": "acme-prod-us-west-2-prod-data.spiceai.io",
+      "endpoint": "acme-prod-us-west-2-prod-data.spiceai.io",
+      "private_endpoint": "private-acme-prod-sandbox-us-west-2-prod-data.spiceai.io",
       "created_at": "2026-06-11T00:00:00Z",
       "updated_at": "2026-06-11T00:00:00Z"
     }
@@ -35,8 +35,8 @@ curl -H "Authorization: Bearer <token>" \
 ```
 
 - **`cluster_name`** — the cluster's identifier. Use it when creating or reassigning apps.
-- **`endpoint`** — the cluster's **private** data-plane host, reachable only over your private connectivity (see [Querying apps](#querying-apps-on-a-dedicated-cluster)).
-- **`public_endpoint`** — the cluster's **public** data-plane host, always reachable over the internet.
+- **`endpoint`** — the cluster's **public** data-plane host, always reachable over the internet.
+- **`private_endpoint`** — the cluster's **private** data-plane host, reachable only over your private connectivity (VPC peering). `null` if the cluster has no private endpoint.
 
 ## Create an app on a dedicated cluster
 
@@ -53,14 +53,15 @@ curl -X POST https://api.spice.ai/v1/apps \
   }'
 ```
 
-The response includes the resolved assignment (`endpoint` is the cluster's private host):
+The response includes the resolved assignment and both endpoints:
 
 ```json
 {
   "id": 123,
   "name": "my-app",
   "cluster_name": "acme-prod-sandbox",
-  "endpoint": "https://private-acme-prod-sandbox-us-west-2-prod-data.spiceai.io",
+  "endpoint": "https://acme-prod-us-west-2-prod-data.spiceai.io",
+  "private_endpoint": "https://private-acme-prod-sandbox-us-west-2-prod-data.spiceai.io",
   "...": "..."
 }
 ```
@@ -97,10 +98,10 @@ Reassigning an app changes its data and Flight endpoints. Update any clients tha
 
 ## Querying apps on a dedicated cluster
 
-`GET /v1/clusters` returns two data-plane hosts for each cluster — use whichever fits your connectivity:
+The app and `GET /v1/clusters` responses return two data-plane hosts — use whichever fits your connectivity:
 
-- **`endpoint`** — the cluster's **private** host (`private-…`). Reachable only when **VPC peering / private connectivity** is enabled for your cluster.
-- **`public_endpoint`** — always reachable over the public internet.
+- **`endpoint`** — the **public** host, always reachable over the internet.
+- **`private_endpoint`** — the **private** host, reachable only when **VPC peering / private connectivity** is enabled for your cluster (`null` if the cluster has none).
 
 Both serve the same APIs (SQL, search, and LLM over HTTP, plus Apache Arrow Flight), and authentication is unchanged — use the app's [API key](../../portal/apps/api-keys.md) or your platform credentials exactly as on shared infrastructure. For Apache Arrow Flight, take either host, replace `-data` with `-flight`, and connect over `grpc+tls://<host>:443`.
 


### PR DESCRIPTION
Documentation for creating and managing apps on a dedicated, single-tenant cluster via the Management API.

- **New page** `cloud/api/management/dedicated-clusters.md`: what a dedicated cluster is, `GET /v1/clusters` discovery, `POST /v1/apps` with `cluster_name` (exactly one of `region`/`cluster_name`; error table for the 400s), `PATCH /v1/apps/{appId}` reassignment with the endpoint-change warning, and the dedicated data/Flight endpoints with a Python SDK example (verified against the documented `Client(api_key, url=...)` signature).
- Nav entry in `cloud/api/SUMMARY.md` under Management API.
- The Management README's create-app example used the deprecated `cname` field — now uses `region`, with a pointer to the new page for `cluster_name`.
