### PR TITLE
docs(cloud): dedicated clusters expose a single connection endpoint

### DIFF
--- a/cloud/api/management/dedicated-clusters.md
+++ b/cloud/api/management/dedicated-clusters.md
@@ -5,7 +5,7 @@ icon: server
 
 # Dedicated Clusters
 
-Organizations on an enterprise plan can have one or more **dedicated clusters**: Spice-managed, single-tenant infrastructure where your apps run only alongside other apps from your organization — never on shared public infrastructure. Each cluster has its own `cluster_name`, isolated network, and query endpoints.
+Organizations on an enterprise plan can have one or more **dedicated clusters**: Spice-managed, single-tenant infrastructure where your apps run only alongside other apps from your organization — never on shared infrastructure. Each cluster has its own `cluster_name`, isolated network, and connection endpoint.
 
 Dedicated clusters are provisioned by Spice.ai. Contact [support](https://spice.ai/support) to request one. Once provisioned and registered to your organization, your clusters are available to the Management API and in the Portal's app-creation picker.
 
@@ -25,8 +25,7 @@ curl -H "Authorization: Bearer <token>" \
       "cluster_name": "acme-prod-sandbox",
       "region": "us-west-2",
       "cloud_provider": "aws",
-      "endpoint": "acme-prod-us-west-2-prod-data.spiceai.io",
-      "private_endpoint": "private-acme-prod-sandbox-us-west-2-prod-data.spiceai.io",
+      "endpoint": "private-acme-prod-sandbox-us-west-2-prod-data.spiceai.io",
       "created_at": "2026-06-11T00:00:00Z",
       "updated_at": "2026-06-11T00:00:00Z"
     }
@@ -35,8 +34,7 @@ curl -H "Authorization: Bearer <token>" \
 ```
 
 - **`cluster_name`** — the cluster's identifier. Use it when creating or reassigning apps.
-- **`endpoint`** — the cluster's **public** data-plane host, always reachable over the internet.
-- **`private_endpoint`** — the cluster's **private** data-plane host, reachable only over your private connectivity (VPC peering). `null` if the cluster has no private endpoint.
+- **`endpoint`** — the cluster's data-plane host. Use it to connect to apps running on this cluster.
 
 ## Create an app on a dedicated cluster
 
@@ -53,15 +51,14 @@ curl -X POST https://api.spice.ai/v1/apps \
   }'
 ```
 
-The response includes the resolved assignment and both endpoints:
+The response includes the resolved assignment and the cluster's endpoint:
 
 ```json
 {
   "id": 123,
   "name": "my-app",
   "cluster_name": "acme-prod-sandbox",
-  "endpoint": "https://acme-prod-us-west-2-prod-data.spiceai.io",
-  "private_endpoint": "https://private-acme-prod-sandbox-us-west-2-prod-data.spiceai.io",
+  "endpoint": "https://private-acme-prod-sandbox-us-west-2-prod-data.spiceai.io",
   "...": "..."
 }
 ```
@@ -97,14 +94,11 @@ Reassigning an app changes its data and Flight endpoints. Update any clients tha
 
 ## Querying apps on a dedicated cluster
 
-The app and `GET /v1/clusters` responses return two data-plane hosts — use whichever fits your connectivity:
+The app and `GET /v1/clusters` responses return the cluster's `endpoint` — the host you connect to.
 
-- **`endpoint`** — the **public** host, always reachable over the internet.
-- **`private_endpoint`** — the **private** host, reachable only when **VPC peering / private connectivity** is enabled for your cluster (`null` if the cluster has none).
+It serves the same APIs (SQL, search, and LLM over HTTP, plus Apache Arrow Flight), and authentication is unchanged — use the app's [API key](../../portal/apps/api-keys.md) or your platform credentials exactly as on shared infrastructure. For Apache Arrow Flight, take the host, replace `-data` with `-flight`, and connect over `grpc+tls://<host>:443`.
 
-Both serve the same APIs (SQL, search, and LLM over HTTP, plus Apache Arrow Flight), and authentication is unchanged — use the app's [API key](../../portal/apps/api-keys.md) or your platform credentials exactly as on shared infrastructure. For Apache Arrow Flight, take either host, replace `-data` with `-flight`, and connect over `grpc+tls://<host>:443`.
-
-When using the [SDKs](../../../sdks/), pass the chosen host in place of the `data.spiceai.io` / `flight.spiceai.io` defaults. For example with the [Python SDK](../../../sdks/python-sdk/), over the private Flight endpoint (VPC peering):
+When using the [SDKs](../../../sdks/), pass the cluster's host in place of the `data.spiceai.io` / `flight.spiceai.io` defaults. For example with the [Python SDK](../../../sdks/python-sdk/), over Flight:
 
 ```python
 from spicepy import Client

--- a/cloud/api/management/dedicated-clusters.md
+++ b/cloud/api/management/dedicated-clusters.md
@@ -25,7 +25,7 @@ curl -H "Authorization: Bearer <token>" \
       "cluster_name": "acme-prod-sandbox",
       "region": "us-west-2",
       "cloud_provider": "aws",
-      "endpoint": "private-acme-prod-sandbox-us-west-2-prod-data.spiceai.io",
+      "endpoint": "https://private-acme-prod-sandbox-us-west-2-prod-data.spiceai.io",
       "created_at": "2026-06-11T00:00:00Z",
       "updated_at": "2026-06-11T00:00:00Z"
     }
@@ -34,7 +34,7 @@ curl -H "Authorization: Bearer <token>" \
 ```
 
 - **`cluster_name`** — the cluster's identifier. Use it when creating or reassigning apps.
-- **`endpoint`** — the cluster's data-plane host. Use it to connect to apps running on this cluster.
+- **`endpoint`** — the cluster's data-plane endpoint (an `https://` URL). Use it to connect to apps running on this cluster.
 
 ## Create an app on a dedicated cluster
 
@@ -94,11 +94,11 @@ Reassigning an app changes its data and Flight endpoints. Update any clients tha
 
 ## Querying apps on a dedicated cluster
 
-The app and `GET /v1/clusters` responses return the cluster's `endpoint` — the host you connect to.
+The app and `GET /v1/clusters` responses return the cluster's `endpoint` — the URL you connect to.
 
-It serves the same APIs (SQL, search, and LLM over HTTP, plus Apache Arrow Flight), and authentication is unchanged — use the app's [API key](../../portal/apps/api-keys.md) or your platform credentials exactly as on shared infrastructure. For Apache Arrow Flight, take the host, replace `-data` with `-flight`, and connect over `grpc+tls://<host>:443`.
+It serves the same APIs (SQL, search, and LLM over HTTP, plus Apache Arrow Flight), and authentication is unchanged — use the app's [API key](../../portal/apps/api-keys.md) or your platform credentials exactly as on shared infrastructure. For Apache Arrow Flight, take the endpoint's host, replace `-data` with `-flight`, and connect over `grpc+tls://<host>:443`.
 
-When using the [SDKs](../../../sdks/), pass the cluster's host in place of the `data.spiceai.io` / `flight.spiceai.io` defaults. For example with the [Python SDK](../../../sdks/python-sdk/), over Flight:
+When using the [SDKs](../../../sdks/), pass the endpoint in place of the `data.spiceai.io` / `flight.spiceai.io` defaults. For example with the [Python SDK](../../../sdks/python-sdk/), over Flight:
 
 ```python
 from spicepy import Client

--- a/cloud/api/management/dedicated-clusters.md
+++ b/cloud/api/management/dedicated-clusters.md
@@ -1,17 +1,17 @@
 ---
-description: Create and manage apps on a dedicated, single-tenant cluster
+description: Creating and managing apps on a dedicated, single-tenant cluster
 icon: server
 ---
 
 # Dedicated Clusters
 
-Organizations on an enterprise plan can have one or more **dedicated clusters**: Spice-managed, single-tenant infrastructure where your apps run only alongside other apps from your organization — never on shared infrastructure. Each cluster has its own `cluster_name`, isolated network, and connection endpoint.
+An organization on an enterprise plan can have one or more **dedicated clusters**: Spice-managed, single-tenant infrastructure where an organization's apps run only alongside other apps from the same organization — never on shared infrastructure. Each cluster has its own `cluster_name`, isolated network, and connection endpoint.
 
-Dedicated clusters are provisioned by Spice.ai. Contact [support](https://spice.ai/support) to request one. Once provisioned and registered to your organization, your clusters are available to the Management API and in the Portal's app-creation picker.
+Dedicated clusters are provisioned by Spice.ai and requested through [support](https://spice.ai/support). Once a cluster is provisioned and registered to an organization, it is available to the Management API and in the Portal's app-creation picker.
 
-## List your clusters
+## Listing clusters
 
-`GET /v1/clusters` returns the dedicated clusters registered to the organization bound to your access token. Requires the `apps:read` scope.
+`GET /v1/clusters` returns the dedicated clusters registered to the organization bound to the access token. It requires the `apps:read` scope.
 
 ```bash
 curl -H "Authorization: Bearer <token>" \
@@ -33,12 +33,12 @@ curl -H "Authorization: Bearer <token>" \
 }
 ```
 
-- **`cluster_name`** — the cluster's identifier. Use it when creating or reassigning apps.
-- **`endpoint`** — the cluster's data-plane endpoint (an `https://` URL). Use it to connect to apps running on this cluster.
+- **`cluster_name`** — the cluster's identifier, used when creating or reassigning apps.
+- **`endpoint`** — the cluster's data-plane endpoint (an `https://` URL); apps running on the cluster are reached at this URL.
 
-## Create an app on a dedicated cluster
+## Creating an app on a dedicated cluster
 
-Pass `cluster_name` instead of `region` when creating an app — set it to a `cluster_name` returned by `GET /v1/clusters`. Provide exactly one of the two; the app's region is derived from the cluster. Requires the `apps:write` scope.
+A create request specifies `cluster_name` instead of `region`, set to a `cluster_name` returned by `GET /v1/clusters`. Exactly one of the two is provided; the app's region is derived from the cluster. The request requires the `apps:write` scope.
 
 ```bash
 curl -X POST https://api.spice.ai/v1/apps \
@@ -47,7 +47,7 @@ curl -X POST https://api.spice.ai/v1/apps \
   -d '{
     "name": "my-app",
     "cluster_name": "acme-prod-sandbox",
-    "description": "My app on our dedicated cluster"
+    "description": "An app on a dedicated cluster"
   }'
 ```
 
@@ -63,7 +63,7 @@ The response includes the resolved assignment and the cluster's endpoint:
 }
 ```
 
-Apps created without `cluster_name` deploy to the shared regional infrastructure as usual; `cluster_name: null` is equivalent to omitting it.
+An app created without `cluster_name` deploys to the shared regional infrastructure as usual; `cluster_name: null` is equivalent to omitting it.
 
 {% hint style="info" %}
 If `region` is also provided it must match the cluster's region.
@@ -73,13 +73,13 @@ If `region` is also provided it must match the cluster's region.
 
 | Status | Cause |
 | ------ | ----- |
-| `400` `Cluster '<name>' not found` | The cluster does not exist or is not registered to your organization |
-| `400` `'<name>' is not a deployable cluster` | The name isn't a cluster you can deploy to — pass a `cluster_name` from `GET /v1/clusters` |
+| `400` `Cluster '<name>' not found` | The cluster does not exist or is not registered to the organization |
+| `400` `'<name>' is not a deployable cluster` | The name is not a deployable cluster — a `cluster_name` from `GET /v1/clusters` is required |
 | `400` `region '<r>' does not match cluster region '<r2>'` | An explicit `region` was provided that differs from the cluster's region |
 
-## Move an existing app to a dedicated cluster
+## Moving an existing app to a dedicated cluster
 
-`PUT /v1/apps/{appId}` with `cluster_name` reassigns the app. Subsequent deployments land on the cluster, and the app's endpoints change to the cluster's hosts.
+`PUT /v1/apps/{appId}` with `cluster_name` reassigns the app. Subsequent deployments land on the cluster, and the app's endpoint changes to the cluster's host.
 
 ```bash
 curl -X PUT https://api.spice.ai/v1/apps/123 \
@@ -89,16 +89,16 @@ curl -X PUT https://api.spice.ai/v1/apps/123 \
 ```
 
 {% hint style="warning" %}
-Reassigning an app changes its data and Flight endpoints. Update any clients that pin the old hostnames, then create a new [deployment](README.md#create-a-deployment) so the app's runtime is placed on the cluster.
+Reassigning an app changes its data and Flight endpoints. Clients that pin the old hostnames must be updated, and a new [deployment](README.md#create-a-deployment) created so the app's runtime is placed on the cluster.
 {% endhint %}
 
 ## Querying apps on a dedicated cluster
 
-The app and `GET /v1/clusters` responses return the cluster's `endpoint` — the URL you connect to.
+The app and `GET /v1/clusters` responses return the cluster's `endpoint` — the URL clients connect to.
 
-It serves the same APIs (SQL, search, and LLM over HTTP, plus Apache Arrow Flight), and authentication is unchanged — use the app's [API key](../../portal/apps/api-keys.md) or your platform credentials exactly as on shared infrastructure. For Apache Arrow Flight, take the endpoint's host, replace `-data` with `-flight`, and connect over `grpc+tls://<host>:443`.
+It serves the same APIs (SQL, search, and LLM over HTTP, plus Apache Arrow Flight), and authentication is unchanged — the app's [API key](../../portal/apps/api-keys.md) or platform credentials work exactly as on shared infrastructure. For Apache Arrow Flight, the endpoint's host is used with `-data` replaced by `-flight`, over `grpc+tls://<host>:443`.
 
-When using the [SDKs](../../../sdks/), pass the endpoint in place of the `data.spiceai.io` / `flight.spiceai.io` defaults. For example with the [Python SDK](../../../sdks/python-sdk/), over Flight:
+With the [SDKs](../../../sdks/), the endpoint replaces the `data.spiceai.io` / `flight.spiceai.io` defaults. For example, with the [Python SDK](../../../sdks/python-sdk/) over Flight:
 
 ```python
 from spicepy import Client
@@ -109,4 +109,4 @@ client = Client(
 )
 ```
 
-Everything else — deployments, secrets, API keys, spicepod configuration — works identically to apps on shared infrastructure. See the [Management APIs](README.md) reference for the full endpoint documentation.
+Everything else — deployments, secrets, API keys, spicepod configuration — works identically to apps on shared infrastructure. The [Management APIs](README.md) reference documents the full endpoint set.


### PR DESCRIPTION
Updates the [Dedicated Clusters](cloud/api/management/dedicated-clusters.md) Management API doc to match an API change made in the cloud: a dedicated cluster (and an app assigned to one) now exposes a single **`endpoint`** — the host you connect to — instead of separate public/private endpoints.

- `GET /v1/clusters` and the app-create response examples show one `endpoint`; removed `private_endpoint` and the public-host example.
- Collapsed the field bullets and the "Querying apps" section to the single endpoint.
- Presents it neutrally as the cluster's connection endpoint (no public/private/VPC-peering framing).

Pairs with spicehq/cloud#4606.