### PR TITLE
Update Kubernetes Operator docs to spice.ai/v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/enterprise/SUMMARY.md
+++ b/enterprise/SUMMARY.md
@@ -28,8 +28,10 @@
 ## Kubernetes Operator
 
 * [Overview](kubernetes/README.md)
+* [User Guide](kubernetes/user-guide.md)
 * [SpicepodSet](kubernetes/spicepodset.md)
 * [SpicepodCluster](kubernetes/spicepodcluster.md)
+* [Operator Metrics](kubernetes/metrics.md)
 
 ## Features
 

--- a/enterprise/kubernetes/README.md
+++ b/enterprise/kubernetes/README.md
@@ -5,20 +5,32 @@ icon: ship
 
 # Kubernetes Operator
 
-The Spice.ai Kubernetes Operator automates the deployment, scaling, and lifecycle management of Spice.ai workloads on Kubernetes. It provides two Custom Resource Definitions (CRDs):
+The Spice.ai Kubernetes Operator automates the deployment, scaling, and lifecycle management of Spice.ai workloads on Kubernetes. It provides two Custom Resource Definitions (CRDs), unified under the `spice.ai/v2beta1` API version:
 
-- **`SpicepodSet`** (`spice.ai/v1`) — Deploys and manages Spicepod replicas as a `Deployment` or per-replica `StatefulSet`s.
-- **`SpicepodCluster`** (`spice.ai/v1alpha1`) — Deploys a distributed query cluster with scheduler and executor nodes, secured with auto-provisioned mTLS certificates.
+- **`SpicepodSet`** (`spice.ai/v2beta1`) — Deploys and manages Spicepod replicas as one or more suffixed `StatefulSet`s.
+- **`SpicepodCluster`** (`spice.ai/v2beta1`) — Deploys a distributed query cluster with scheduler and executor nodes, secured with auto-provisioned mTLS certificates.
+
+{% hint style="info" %}
+`v2beta1` consolidates the previous `spice.ai/v1` (`SpicepodSet`) and `spice.ai/v1alpha1` (`SpicepodCluster`) schemas. Existing `v1` / `v1alpha1` manifests keep working and are converted automatically — no immediate action required.
+{% endhint %}
+
+For a step-by-step walkthrough, see the [User Guide](user-guide.md). For exhaustive field references, see [SpicepodSet](spicepodset.md) and [SpicepodCluster](spicepodcluster.md).
 
 ## Installation
 
-The Spice Kubernetes Operator is distributed exclusively through the [AWS Marketplace](../deployment/aws-marketplace.md) Spice.ai Enterprise listing. Subscribe and authenticate to the Marketplace ECR registry, then install:
+### Prerequisites
+
+- Kubernetes 1.33+
+- Helm 3.x
+
+The Spice Kubernetes Operator is distributed through the [AWS Marketplace](../deployment/aws-marketplace.md) Spice.ai Enterprise listing. Subscribe and authenticate to the Marketplace ECR registry, then install. The chart installs and updates the CRDs by default (`installCRDs: true`).
 
 ### Helm
 
 ```bash
 helm install spiceai-operator \
-  oci://709825985650.dkr.ecr.us-east-1.amazonaws.com/spice-ai/charts/spiceai-operator
+  oci://709825985650.dkr.ecr.us-east-1.amazonaws.com/spice-ai/charts/spiceai-operator \
+  --namespace spiceai-operator-system --create-namespace
 ```
 
 ### Docker
@@ -27,68 +39,71 @@ helm install spiceai-operator \
 docker pull 709825985650.dkr.ecr.us-east-1.amazonaws.com/spice-ai/spiceai-operator:latest
 ```
 
+{% hint style="info" %}
+Multi-architecture (`linux/amd64` and `linux/arm64`) operator images are also published to GitHub Container Registry at `ghcr.io/spicehq/spiceai-operator`. Override the operator image with `--set image.repository=ghcr.io/spicehq/spiceai-operator`; the tag tracks the chart `appVersion` unless pinned with `--set image.tag=<version>`.
+{% endhint %}
+
 ### Helm Values
 
-| Parameter                              | Description                                                                       | Default                                                       |
-| -------------------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| `image.repository`                     | Operator image repository                                                         | `709825985650.dkr.ecr.us-east-1.amazonaws.com`                |
-| `image.name`                           | Operator image name                                                               | `spice-ai/spiceai-operator`                                   |
-| `image.tag`                            | Operator image tag                                                                | `latest`                                                      |
-| `image.pullPolicy`                     | Operator image pull policy                                                        | `IfNotPresent`                                                |
-| `image.pullSecrets`                    | Image pull secrets                                                                | —                                                             |
-| `installCRDs`                          | Install/update CRDs with the chart                                                | `true`                                                        |
-| `serviceAccount.create`                | Create a ServiceAccount for the operator                                          | `true`                                                        |
-| `serviceAccount.name`                  | ServiceAccount name                                                               | (chart name)                                                  |
-| `serviceAccount.annotations`           | Annotations for the operator ServiceAccount (e.g. for IRSA)                       | `{}`                                                          |
-| `resources`                            | CPU/memory `requests` and `limits` for the operator container                     | —                                                             |
-| `nodeSelector` / `tolerations` / `affinity` | Operator pod scheduling                                                      | —                                                             |
-| `serviceMonitor.enabled`               | Enable Prometheus `ServiceMonitor`                                                | `false`                                                       |
-| `serviceMonitor.interval`              | Scrape interval                                                                   | `30s`                                                         |
-| `cluster.domain`                       | Kubernetes cluster domain for internal DNS                                        | `cluster.local`                                               |
-| `pauseCrashloopingPodsThreshold`       | Crashlooping pod threshold before pausing a `SpicepodSet` (`0` disables)          | `10`                                                          |
-| `sidecarInjector.defaultImage`         | Default image used by the sidecar injector when no per-Pod override is set        | (operator default)                                            |
-| `sidecarInjector.defaultImagePullPolicy` | Default pull policy for injected sidecars                                       | (operator default)                                            |
-| `telemetryProperties`                  | Key/value pairs forwarded to the Spice runtime as telemetry properties            | `{}`                                                          |
+| Parameter                                                  | Description                                                                     | Default                       |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------- | ----------------------------- |
+| `image.repository`                                         | Operator image path (registry + name)                                           | `…/spice-ai/spiceai-operator` |
+| `image.tag`                                                | Operator image tag                                                              | Chart `appVersion`            |
+| `image.pullPolicy`                                         | Operator image pull policy                                                      | `IfNotPresent`                |
+| `image.pullSecrets`                                        | Image pull secrets                                                              | —                             |
+| `installCRDs`                                              | Install/update CRDs with the chart                                              | `true`                        |
+| `serviceAccount.create` / `.name` / `.annotations`         | Operator ServiceAccount (annotations for IRSA)                                  | `true` / chart name / `{}`    |
+| `resources`                                                | CPU/memory `requests` and `limits` for the operator                             | —                             |
+| `nodeSelector` / `tolerations` / `affinity`                | Operator pod scheduling                                                         | —                             |
+| `serviceMonitor.enabled` / `.interval`                     | Prometheus `ServiceMonitor` for the operator                                    | `false` / `30s`               |
+| `clusterDomain`                                            | Kubernetes cluster domain for internal DNS                                      | `cluster.local`               |
+| `pauseCrashloopingPodsThreshold`                           | Crashloop threshold before pausing a `SpicepodSet` (`0` disables)               | `0`                           |
+| `admissionPolicy`                                          | Admission validation strictness: `err` \| `warn` \| `off`                       | `err`                         |
+| `sidecarInjector.enabled`                                  | Enable annotation-based sidecar injection                                       | `true`                        |
+| `sidecarInjector.defaultImage` / `.defaultImagePullPolicy` | Defaults for injected sidecars                                                  | (operator default)            |
+| `watchNamespaces` / `denyNamespaces`                       | Scope the operator to / away from specific namespaces                           | (all namespaces)              |
+| `tls.enabled` / `tls.secretName`                           | Serve the operator API over HTTPS from a `kubernetes.io/tls` Secret             | `false` / —                   |
+| `telemetry.otlp.*`                                         | Push operator metrics to an OTLP collector (see [Operator Metrics](metrics.md)) | disabled                      |
+| `telemetryProperties`                                      | Key/value pairs forwarded to the Spice runtime as telemetry properties          | `{}`                          |
 
 ## Managed Resources
 
 For each `SpicepodSet`, the operator creates and manages:
 
-1. **ServiceAccount** — When `service_account.enabled` and `service_account.create` are `true`.
-2. **Role** — Scoped permissions for Spicepod pods.
-3. **RoleBinding** — Binds the Role to the ServiceAccount.
-4. **ConfigMap** — Stores the `spicepod` YAML, mounted into the pod.
-5. **NetworkPolicy** — Controls ingress/egress traffic.
-6. **Deployment / StatefulSet(s)** — The primary workload.
-7. **Service** — `ClusterIP` service exposing HTTP (`8090`), Flight (`50051`), and metrics (`9090`).
+1. **StatefulSet(s)** — One per replica (each with an ordinal suffix), managing the pods.
+2. **ConfigMap** — Stores the `spicepod` YAML, mounted into the pod.
+3. **Service** — `ClusterIP` service exposing fixed ports HTTP (`8080`), Flight (`50051`), and metrics (`9090`), mapped via `targetPort` to the configured Spiced ports. Disable with `service.enabled: false`.
+4. **NetworkPolicy** — Only when `network.ingress` / `network.egress` is supplied; rules are written verbatim.
+5. **ServiceAccount, Role, RoleBinding** — Only when `serviceAccount.enabled` and `serviceAccount.create` are both `true`.
 
-## Adaptive Workload Deployment
+## Workload Deployment
 
-For simple stateless cases (no `volume`, no `cluster`, `replicas <= 1`), the operator uses a `Deployment`. When `volume`, `cluster`, or `replicas > 1` is configured, the operator creates per-replica `StatefulSet`s with stable pod identities and ordered startup. Switching between modes is automatic when the spec changes.
+Every `SpicepodSet` is deployed as one or more `StatefulSet`s — one per replica, each with an ordinal suffix — so even single-replica workloads get a stable identity, ordered startup, and predictable DNS, with zero-downtime rollouts. Rolling updates, `BlueGreen` cutovers, and standby retention are expressed as parallel suffixed `StatefulSet`s. Pre-existing v0.x `Deployment`-based workloads are reliably grandfathered and continue to reconcile.
 
 ## Features
 
-| Feature                                    | SpicepodSet | SpicepodCluster |
-| ------------------------------------------ | :---------: | :-------------: |
-| Adaptive workload deployment               |      ✓      |        ✓        |
-| Update strategies (`RollingOrdered`, `RollingParallel`, `Parallel`, `BlueGreen`) | ✓ | ✓ |
-| Instant rollback via `spice.ai/rollback`   |      ✓      |        ✓        |
-| Persistent volume with auto-resize         |      ✓      |        ✓        |
-| Zero-replica pausing                       |      ✓      |        ✓        |
-| Crashloop protection                       |      ✓      |        ✓        |
-| Forced rollouts via annotations/labels     |      ✓      |        ✓        |
-| Network policy management                  |      ✓      |        ✓        |
-| Service account configuration (incl. IRSA) |      ✓      |        ✓        |
-| Health probe customization                 |      ✓      |        ✓        |
-| Pod scheduling (affinity, tolerations)     |      ✓      |        ✓        |
-| Sidecar injection via Pod annotations      |      —      |        —        |
-| Automatic mTLS certificates                |      —      |        ✓        |
-| Distributed scheduler/executor topology    |      —      |        ✓        |
-| Prometheus metrics & ServiceMonitor        |      ✓      |        ✓        |
+| Feature                                                              | SpicepodSet | SpicepodCluster |
+| -------------------------------------------------------------------- | :---------: | :-------------: |
+| Workload deployment (suffixed StatefulSets)                          |      ✓      |        ✓        |
+| Update strategies (`RollingOrdered`, `RollingParallel`, `BlueGreen`) |      ✓      |        ✓        |
+| Standby versions & instant rollback (SHA)                            |      ✓      |        —        |
+| Persistent volume with auto-resize                                   |      ✓      |        ✓        |
+| Zero-replica pausing                                                 |      ✓      |        ✓        |
+| Crashloop protection                                                 |      ✓      |        ✓        |
+| Forced rollouts via annotations/labels                               |      ✓      |        ✓        |
+| Network policy management (opt-in)                                   |      ✓      |        ✓        |
+| Service account configuration (incl. IRSA)                           |      ✓      |        ✓        |
+| Health probe customization                                           |      ✓      |        ✓        |
+| Pod scheduling (affinity, tolerations)                               |      ✓      |        ✓        |
+| Admission validation                                                 |      ✓      |        ✓        |
+| Status conditions (`Ready`, `Paused`)                                |      ✓      |        ✓        |
+| Automatic mTLS certificates                                          |      —      |        ✓        |
+| Distributed scheduler/executor topology                              |      —      |        ✓        |
+| Prometheus metrics, ServiceMonitor & OTLP                            |      ✓      |        ✓        |
 
 ## Sidecar Injection
 
-The operator can inject a Spice sidecar into any standard Kubernetes Pod by annotating the Pod template with `spice.ai/inject` and pointing it at a `ConfigMap` in the same namespace that holds your `spicepod.yaml`. For the common case, `spice.ai/inject` can name the ConfigMap directly:
+The operator can inject a Spice sidecar into any standard Kubernetes Pod by annotating the Pod template with `spice.ai/inject: "true"` and pointing `spice.ai/inject-config` at a `ConfigMap` in the same namespace that holds your `spicepod.yaml`:
 
 ```yaml
 apiVersion: v1
@@ -113,7 +128,8 @@ spec:
     metadata:
       labels: { app: app-with-spice }
       annotations:
-        spice.ai/inject: demo-spice-config
+        spice.ai/inject: "true"
+        spice.ai/inject-config: demo-spice-config
     spec:
       containers:
         - name: app
@@ -122,22 +138,22 @@ spec:
 
 ### Supported annotations
 
-| Annotation                     | Default          | Description                                                                                  |
-| ------------------------------ | ---------------- | -------------------------------------------------------------------------------------------- |
-| `spice.ai/inject`              | —                | `true`/`enabled`, `false`/`disabled`, **or** a ConfigMap name (one-annotation shorthand).     |
-| `spice.ai/spicepod-configmap`  | —                | ConfigMap holding the spicepod. Optional when `spice.ai/inject` already names the ConfigMap. |
-| `spice.ai/spicepod-key`        | `spicepod.yaml`  | Key inside the ConfigMap data.                                                               |
-| `spice.ai/image`               | install default  | Override the injected Spice image.                                                           |
-| `spice.ai/image-pull-policy`   | install default  | Override the injected image pull policy.                                                     |
-| `spice.ai/http-port`           | `18090`          | Sidecar HTTP port.                                                                           |
-| `spice.ai/flight-port`         | `15051`          | Sidecar Arrow Flight port.                                                                   |
-| `spice.ai/metrics-port`        | `19090`          | Sidecar Prometheus metrics port.                                                             |
+| Annotation                   | Default         | Description                                                     |
+| ---------------------------- | --------------- | --------------------------------------------------------------- |
+| `spice.ai/inject`            | —               | `"true"` / `"false"` — enable or disable injection for the Pod. |
+| `spice.ai/inject-config`     | —               | ConfigMap holding the spicepod.                                 |
+| `spice.ai/inject-config-key` | `spicepod.yaml` | Key inside the ConfigMap data.                                  |
+| `spice.ai/image`             | install default | Override the injected Spice image.                              |
+| `spice.ai/image-pull-policy` | install default | Override the injected image pull policy.                        |
+| `spice.ai/http-port`         | `18090`         | Sidecar HTTP port.                                              |
+| `spice.ai/flight-port`       | `15051`         | Sidecar Arrow Flight port.                                      |
+| `spice.ai/metrics-port`      | `19090`         | Sidecar Prometheus metrics port.                                |
 
 {% hint style="info" %}
 Injection runs on Pod creation, so place these annotations on the controller's Pod template (e.g. `Deployment.spec.template.metadata.annotations`) and `kubectl rollout restart` to pick up changes. The ConfigMap must already exist when the Pod is created. The webhook rejects Pods whose existing container ports collide with the requested sidecar ports.
 {% endhint %}
 
-Cluster operators can set defaults globally via Helm values `sidecarInjector.defaultImage` and `sidecarInjector.defaultImagePullPolicy`, with per-workload annotations as overrides.
+Cluster operators can set defaults globally via Helm values `sidecarInjector.defaultImage` and `sidecarInjector.defaultImagePullPolicy`, with per-workload annotations as overrides. The sidecar injector is enabled by default (`sidecarInjector.enabled`); disable it with `--no-sidecar-injector`.
 
 ## Operator CLI
 
@@ -153,10 +169,15 @@ spiceai-operator crd --output FILE
 
 | Flag                                  | Default                   | Description                                                  |
 | ------------------------------------- | ------------------------- | ------------------------------------------------------------ |
-| `--http-endpoint`                     | `0.0.0.0:8090`            | Operator HTTP API bind address                                |
-| `--metrics-endpoint`                  | `0.0.0.0:9090`            | Prometheus metrics bind address                              |
+| `--health-probe-bind-address`         | `0.0.0.0:8090`            | Operator HTTP API / health probe bind address                |
+| `--metrics-bind-address`              | `0.0.0.0:9090`            | Prometheus metrics bind address                              |
+| `--webhook-bind-address`              | —                         | Admission / conversion webhook bind address                  |
 | `--operator-namespace`                | `spiceai-operator-system` | Namespace for the operator (used for cluster-shared secrets) |
 | `--cluster-domain`                    | `cluster.local`           | Kubernetes cluster domain                                    |
+| `--admission-policy`                  | `err`                     | Admission validation strictness (`err` \| `warn` \| `off`)   |
+| `--watch-namespaces`                  | (all)                     | Comma-separated namespaces to watch exclusively              |
+| `--deny-namespaces`                   | —                         | Comma-separated namespaces to exclude from watching          |
+| `--enable-sidecar-injector`           | `true`                    | Enable sidecar injection (`--no-sidecar-injector` disables)  |
 | `--pause-crashlooping-pods-threshold` | `10`                      | Dead pod observations before pausing (`0` disables)          |
 | `--telemetry-properties KEY=VALUE`    | —                         | Key/value pairs forwarded to the Spice runtime               |
 | `--verbose`                           | `false`                   | Enable debug-level logging                                   |
@@ -170,11 +191,11 @@ spiceai-operator json-schema --output FILE
 
 ## Operator HTTP API
 
-| Endpoint                                   | Method | Description                                                                              |
-| ------------------------------------------ | ------ | ---------------------------------------------------------------------------------------- |
-| `/health`                                  | GET    | Health check — returns `OK`                                                              |
-| `/{namespace}/{name}`                      | GET    | Pod status for a `SpicepodSet`                                                           |
-| `/{namespace}/{name}?kind=SpicepodCluster` | GET    | Pod status for a `SpicepodCluster`                                                       |
+| Endpoint                                   | Method | Description                        |
+| ------------------------------------------ | ------ | ---------------------------------- |
+| `/health`                                  | GET    | Health check — returns `OK`        |
+| `/{namespace}/{name}`                      | GET    | Pod status for a `SpicepodSet`     |
+| `/{namespace}/{name}?kind=SpicepodCluster` | GET    | Pod status for a `SpicepodCluster` |
 
 The pod-status response includes per-pod details (name, UID, phase, IP, port, start time, Spiced health/readiness, and any error reason/message). For paused `SpicepodSet`s (`replicas: 0`), the response includes `paused: true` with a `pauseReason`.
 
@@ -185,3 +206,19 @@ helm upgrade spiceai-operator \
   oci://709825985650.dkr.ecr.us-east-1.amazonaws.com/spice-ai/charts/spiceai-operator \
   --values my-values.yaml
 ```
+
+`v2beta1` is served with automatic conversion of legacy `v1` / `v1alpha1` resources, so existing manifests continue to apply after the upgrade. See the [User Guide](user-guide.md) for rollout guidance and the per-CRD field changes in [SpicepodSet](spicepodset.md#migrating-from-spiceaiv1) and [SpicepodCluster](spicepodcluster.md).
+
+## Roadmap
+
+Capabilities in active development and planned for the operator include:
+
+- **Leader election** for multi-replica operator high availability.
+- **Custom API-server TLS** with a user-supplied certificate and CA bundle.
+- **Log drains** to forward Spicepod logs to external sinks (Datadog, Splunk, CloudWatch, …).
+- **Audit logging** of operator and workload lifecycle events.
+- **Cedar policy enforcement** distributed to Spicepod pods.
+- **Auto-scaling** via `HorizontalPodAutoscaler` and Spiced-specific metrics.
+- **Backup & restore** of stateful volumes via `VolumeSnapshot`.
+- **Secret rotation** with automatic rolling restarts.
+- **Spice Cloud Platform integration** for centralized fleet management and observability.

--- a/enterprise/kubernetes/README.md
+++ b/enterprise/kubernetes/README.md
@@ -5,13 +5,13 @@ icon: ship
 
 # Kubernetes Operator
 
-The Spice.ai Kubernetes Operator automates the deployment, scaling, and lifecycle management of Spice.ai workloads on Kubernetes. It provides two Custom Resource Definitions (CRDs), unified under the `spice.ai/v2beta1` API version:
+The Spice.ai Kubernetes Operator automates the deployment, scaling, and lifecycle management of Spice.ai workloads on Kubernetes. It provides two Custom Resource Definitions (CRDs), unified under the `spice.ai/v2` API version:
 
-- **`SpicepodSet`** (`spice.ai/v2beta1`) — Deploys and manages Spicepod replicas as one or more suffixed `StatefulSet`s.
-- **`SpicepodCluster`** (`spice.ai/v2beta1`) — Deploys a distributed query cluster with scheduler and executor nodes, secured with auto-provisioned mTLS certificates.
+- **`SpicepodSet`** (`spice.ai/v2`) — Deploys and manages Spicepod replicas as one or more suffixed `StatefulSet`s.
+- **`SpicepodCluster`** (`spice.ai/v2`) — Deploys a distributed query cluster with scheduler and executor nodes, secured with auto-provisioned mTLS certificates.
 
 {% hint style="info" %}
-`v2beta1` consolidates the previous `spice.ai/v1` (`SpicepodSet`) and `spice.ai/v1alpha1` (`SpicepodCluster`) schemas. Existing `v1` / `v1alpha1` manifests keep working and are converted automatically — no immediate action required.
+`v2` consolidates the previous `spice.ai/v1` (`SpicepodSet`) and `spice.ai/v1alpha1` (`SpicepodCluster`) schemas. Existing `v1` / `v1alpha1` manifests keep working and are converted automatically — no immediate action required.
 {% endhint %}
 
 For a step-by-step walkthrough, see the [User Guide](user-guide.md). For exhaustive field references, see [SpicepodSet](spicepodset.md) and [SpicepodCluster](spicepodcluster.md).
@@ -207,7 +207,7 @@ helm upgrade spiceai-operator \
   --values my-values.yaml
 ```
 
-`v2beta1` is served with automatic conversion of legacy `v1` / `v1alpha1` resources, so existing manifests continue to apply after the upgrade. See the [User Guide](user-guide.md) for rollout guidance and the per-CRD field changes in [SpicepodSet](spicepodset.md#migrating-from-spiceaiv1) and [SpicepodCluster](spicepodcluster.md).
+`v2` is served with automatic conversion of legacy `v1` / `v1alpha1` resources, so existing manifests continue to apply after the upgrade. See the [User Guide](user-guide.md) for rollout guidance and the per-CRD field changes in [SpicepodSet](spicepodset.md#migrating-from-spiceaiv1) and [SpicepodCluster](spicepodcluster.md).
 
 ## Roadmap
 

--- a/enterprise/kubernetes/README.md
+++ b/enterprise/kubernetes/README.md
@@ -23,20 +23,20 @@ For a step-by-step walkthrough, see the [User Guide](user-guide.md). For exhaust
 - Kubernetes 1.33+
 - Helm 3.x
 
-The Spice Kubernetes Operator is distributed through the [AWS Marketplace](../deployment/aws-marketplace.md) Spice.ai Enterprise listing. Subscribe and authenticate to the Marketplace ECR registry, then install. The chart installs and updates the CRDs by default (`installCRDs: true`).
+The Spice Kubernetes Operator is distributed through the [AWS Marketplace](../deployment/aws-marketplace.md) Spice.ai Enterprise listing. Subscribe and authenticate to the Marketplace ECR registry, then install. The chart renders and keeps the CRDs by default (`crds.enabled: true`, `crds.keep: true`).
 
 ### Helm
 
 ```bash
 helm install spiceai-operator \
-  oci://709825985650.dkr.ecr.us-east-1.amazonaws.com/spice-ai/charts/spiceai-operator \
+  oci://709825985650.dkr.ecr.us-east-1.amazonaws.com/spice-ai/spiceai-enterprise-plan:1.0.0-operator-helm \
   --namespace spiceai-operator-system --create-namespace
 ```
 
 ### Docker
 
 ```bash
-docker pull 709825985650.dkr.ecr.us-east-1.amazonaws.com/spice-ai/spiceai-operator:latest
+docker pull 709825985650.dkr.ecr.us-east-1.amazonaws.com/spice-ai/spiceai-enterprise-plan:1.0.0-operator
 ```
 
 {% hint style="info" %}
@@ -47,22 +47,23 @@ Multi-architecture (`linux/amd64` and `linux/arm64`) operator images are also pu
 
 | Parameter                                                  | Description                                                                     | Default                       |
 | ---------------------------------------------------------- | ------------------------------------------------------------------------------- | ----------------------------- |
-| `image.repository`                                         | Operator image path (registry + name)                                           | `…/spice-ai/spiceai-operator` |
-| `image.tag`                                                | Operator image tag                                                              | Chart `appVersion`            |
+| `image.repository`                                         | Operator image path (registry + name)                                           | `…/spice-ai/spiceai-enterprise-plan` |
+| `image.tag`                                                | Operator image tag (operator-suffixed chart `appVersion`)                       | `1.0.0-operator`              |
 | `image.pullPolicy`                                         | Operator image pull policy                                                      | `IfNotPresent`                |
 | `image.pullSecrets`                                        | Image pull secrets                                                              | —                             |
-| `installCRDs`                                              | Install/update CRDs with the chart                                              | `true`                        |
+| `crds.enabled`                                             | Render the bundled CRDs with the chart                                          | `true`                        |
+| `crds.keep`                                                | Annotate CRDs with `helm.sh/resource-policy: keep` so `helm uninstall` leaves them (and their custom resources) in place | `true`     |
+| `installCRDs`                                              | **Deprecated** — prefer `crds.enabled` / `crds.keep`. A boolean here overrides both (`true` ≡ `{enabled: true, keep: true}`, `false` disables CRD rendering). Leave unset to use the `crds` block. | unset |
 | `serviceAccount.create` / `.name` / `.annotations`         | Operator ServiceAccount (annotations for IRSA)                                  | `true` / chart name / `{}`    |
 | `resources`                                                | CPU/memory `requests` and `limits` for the operator                             | —                             |
 | `nodeSelector` / `tolerations` / `affinity`                | Operator pod scheduling                                                         | —                             |
-| `serviceMonitor.enabled` / `.interval`                     | Prometheus `ServiceMonitor` for the operator                                    | `false` / `30s`               |
+| `serviceMonitor.enabled` / `.interval`                     | Prometheus `ServiceMonitor` for the operator                                    | `false` / `15s`               |
 | `clusterDomain`                                            | Kubernetes cluster domain for internal DNS                                      | `cluster.local`               |
 | `pauseCrashloopingPodsThreshold`                           | Crashloop threshold before pausing a `SpicepodSet` (`0` disables)               | `0`                           |
 | `admissionPolicy`                                          | Admission validation strictness: `err` \| `warn` \| `off`                       | `err`                         |
 | `sidecarInjector.enabled`                                  | Enable annotation-based sidecar injection                                       | `true`                        |
 | `sidecarInjector.defaultImage` / `.defaultImagePullPolicy` | Defaults for injected sidecars                                                  | (operator default)            |
-| `watchNamespaces` / `denyNamespaces`                       | Scope the operator to / away from specific namespaces                           | (all namespaces)              |
-| `tls.enabled` / `tls.secretName`                           | Serve the operator API over HTTPS from a `kubernetes.io/tls` Secret             | `false` / —                   |
+| `namespaces` / `denyNamespaces`                            | Scope the operator to / away from specific namespaces (mutually exclusive)      | (all namespaces)              |
 | `telemetry.otlp.*`                                         | Push operator metrics to an OTLP collector (see [Operator Metrics](metrics.md)) | disabled                      |
 | `telemetryProperties`                                      | Key/value pairs forwarded to the Spice runtime as telemetry properties          | `{}`                          |
 
@@ -157,6 +158,8 @@ Cluster operators can set defaults globally via Helm values `sidecarInjector.def
 
 ## Operator CLI
 
+The released operator image ships only the `run` subcommand. The `crd` and `json-schema` subcommands below are development/tooling helpers compiled into debug builds only — they are not present in the standard release binary, and CRDs are installed via the Helm chart rather than `crd --apply`.
+
 ### `crd` — Output or apply CRD definitions
 
 ```bash
@@ -171,7 +174,7 @@ spiceai-operator crd --output FILE
 | ------------------------------------- | ------------------------- | ------------------------------------------------------------ |
 | `--health-probe-bind-address`         | `0.0.0.0:8090`            | Operator HTTP API / health probe bind address                |
 | `--metrics-bind-address`              | `0.0.0.0:9090`            | Prometheus metrics bind address                              |
-| `--webhook-bind-address`              | —                         | Admission / conversion webhook bind address                  |
+| `--webhook-bind-address`              | `0.0.0.0:8443`            | Admission / conversion webhook bind address                  |
 | `--operator-namespace`                | `spiceai-operator-system` | Namespace for the operator (used for cluster-shared secrets) |
 | `--cluster-domain`                    | `cluster.local`           | Kubernetes cluster domain                                    |
 | `--admission-policy`                  | `err`                     | Admission validation strictness (`err` \| `warn` \| `off`)   |
@@ -191,9 +194,21 @@ spiceai-operator json-schema --output FILE
 
 ## Operator HTTP API
 
+The operator serves an HTTP API on `--health-probe-bind-address` (`0.0.0.0:8090` by default). The standard build exposes only the health and readiness endpoints:
+
+| Endpoint  | Method | Description                                            |
+| --------- | ------ | ------------------------------------------------------ |
+| `/health` | GET    | Health check — returns `OK`                            |
+| `/ready`  | GET    | Readiness probe — `200` once the operator has bootstrapped, `503` otherwise |
+
+### Pod-status API (deprecated)
+
+{% hint style="warning" %}
+The pod-status endpoints below are **deprecated** and slated for removal in a future release. They are **not** compiled into the standard operator build - they are available only in builds with the `status-api` feature enabled, which logs a deprecation warning on startup. Do not rely on them for new integrations.
+{% endhint %}
+
 | Endpoint                                   | Method | Description                        |
 | ------------------------------------------ | ------ | ---------------------------------- |
-| `/health`                                  | GET    | Health check — returns `OK`        |
 | `/{namespace}/{name}`                      | GET    | Pod status for a `SpicepodSet`     |
 | `/{namespace}/{name}?kind=SpicepodCluster` | GET    | Pod status for a `SpicepodCluster` |
 

--- a/enterprise/kubernetes/metrics.md
+++ b/enterprise/kubernetes/metrics.md
@@ -1,0 +1,133 @@
+---
+description: Prometheus scraping and OTLP push for Spice.ai Kubernetes Operator self-telemetry.
+icon: gauge-high
+---
+
+# Operator Metrics
+
+The operator emits self-telemetry about its own behavior — controller reconcile counts and durations, Kubernetes API call latencies, managed-resource counts, and certificate expiry — through two independent readers:
+
+1. **Prometheus scraping** — always on. The operator exposes a `/metrics` endpoint for pull-based collection.
+2. **OTLP push** — opt-in. The operator pushes metrics to an OpenTelemetry collector or a compatible vendor endpoint.
+
+Both readers can run at the same time and observe the same instruments.
+
+{% hint style="info" %}
+These are the **operator's** metrics. Metrics emitted by the Spiced runtime inside each Spicepod are exposed on each pod's own metrics port (default `9090`) and the managed `Service`; see the [SpicepodSet reference](spicepodset.md#ports).
+{% endhint %}
+
+## Prometheus scraping
+
+The operator serves Prometheus metrics on its metrics bind address (`--metrics-bind-address`, default `0.0.0.0:9090`) at `/metrics`. This reader is always enabled.
+
+```bash
+kubectl -n spiceai-operator-system port-forward deploy/spiceai-operator 9090:9090
+curl http://localhost:9090/metrics
+```
+
+If the Prometheus Operator is installed, enable a `ServiceMonitor` so the operator is scraped automatically:
+
+```yaml
+# Helm values for the operator
+serviceMonitor:
+  enabled: true
+  interval: 30s
+```
+
+## OTLP push
+
+OTLP export is disabled by default. Enable it through the chart's `telemetry.otlp` values:
+
+```yaml
+# Helm values for the operator
+telemetry:
+  otlp:
+    enabled: true
+    endpoint: http://otel-collector.observability.svc:4317
+    protocol: grpc            # grpc | http/protobuf
+    temporality: delta        # cumulative | delta | lowmemory
+    interval: 60s             # export interval
+    headers:
+      authorization: "Bearer ${OTLP_TOKEN}"
+```
+
+These values configure the operator through the standard OpenTelemetry SDK environment variables, which you can also set directly (for example via `extraEnv`):
+
+| Environment variable                                | Description                                                     | Example                                 |
+| --------------------------------------------------- | --------------------------------------------------------------- | --------------------------------------- |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`                       | Base OTLP endpoint for all signals.                             | `http://otel-collector:4317`            |
+| `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`               | Metrics-specific endpoint override.                             | `http://otel-collector:4317/v1/metrics` |
+| `OTEL_EXPORTER_OTLP_PROTOCOL`                       | Transport protocol: `grpc` or `http/protobuf`.                  | `grpc`                                  |
+| `OTEL_EXPORTER_OTLP_HEADERS`                        | Comma-separated `key=value` headers (e.g. authentication).      | `authorization=Bearer abc123`           |
+| `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` | Aggregation temporality: `cumulative`, `delta`, or `lowmemory`. | `delta`                                 |
+| `OTEL_METRIC_EXPORT_INTERVAL`                       | Export interval in milliseconds.                                | `60000`                                 |
+| `OTEL_SERVICE_NAME`                                 | `service.name` resource attribute.                              | `spiceai-operator`                      |
+| `OTEL_RESOURCE_ATTRIBUTES`                          | Additional resource attributes as `key=value` pairs.            | `deployment.environment=prod`           |
+
+### Choose the right temporality
+
+The correct aggregation temporality depends on your backend. Most hosted observability vendors expect **delta**, while Prometheus-compatible time-series databases expect **cumulative**.
+
+| Backend                                                    | Recommended `temporality` |
+| ---------------------------------------------------------- | ------------------------- |
+| Datadog                                                    | `delta`                   |
+| AWS CloudWatch                                             | `delta`                   |
+| New Relic                                                  | `delta`                   |
+| Prometheus, Grafana Mimir, Cortex, Thanos, VictoriaMetrics | `cumulative`              |
+| Memory-constrained collectors                              | `lowmemory`               |
+
+{% hint style="warning" %}
+Sending the wrong temporality is a common cause of missing or incorrect rates: delta points pushed to a cumulative backend (or vice versa) produce broken counters. When in doubt, match your backend from the table above.
+{% endhint %}
+
+`lowmemory` uses delta temporality for counters and histograms (which can be reset after export) while keeping gauges and up-down counters cumulative, minimizing in-process state for resource-constrained deployments.
+
+## Metric prefix
+
+A configurable prefix is prepended to every metric name. It applies to **both** the Prometheus and OTLP readers, so dashboards and alerts stay consistent regardless of how metrics are collected. Set it through the chart (or the corresponding environment variable) to namespace operator metrics within a shared backend, for example `spice_operator_`.
+
+## Metric whitelist (OTLP only)
+
+The OTLP reader supports an optional allow-list to restrict which metrics are exported — useful for limiting cardinality or cost on a hosted backend. When set, only the named metrics are pushed over OTLP.
+
+{% hint style="info" %}
+The whitelist applies to the **OTLP reader only**. The Prometheus `/metrics` endpoint always exposes the full set of metrics for local scraping.
+{% endhint %}
+
+## Example: OpenTelemetry Collector
+
+A minimal collector configuration that receives the operator's OTLP metrics and forwards them to a backend:
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+processors:
+  batch: {}
+
+exporters:
+  prometheusremotewrite:
+    endpoint: https://mimir.example.com/api/v1/push
+  # or: datadog, awsemf, otlphttp, ...
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [prometheusremotewrite]
+```
+
+Point the operator at the collector's OTLP gRPC port (`4317`) and choose `temporality: cumulative` for the Prometheus-remote-write path above, or `delta` when exporting to Datadog / CloudWatch / New Relic.
+
+## Resilient initialization
+
+Telemetry setup is defensive: if the OTLP endpoint is unreachable or misconfigured at startup, the operator logs the error and continues running with the Prometheus reader rather than crashing. Export failures are retried and never block reconciliation, so a metrics outage cannot take down your workloads.
+
+## See also
+
+- [Overview — Helm Values](README.md#helm-values) — the `telemetry.otlp.*` and `serviceMonitor.*` values.
+- [SpicepodSet — Monitoring](spicepodset.md#monitoring) — telemetry properties for the Spiced runtime.

--- a/enterprise/kubernetes/metrics.md
+++ b/enterprise/kubernetes/metrics.md
@@ -44,11 +44,12 @@ telemetry:
   otlp:
     enabled: true
     endpoint: http://otel-collector.observability.svc:4317
-    protocol: grpc            # grpc | http/protobuf
-    temporality: delta        # cumulative | delta | lowmemory
-    interval: 60s             # export interval
+    protocol: grpc              # grpc | http/protobuf
     headers:
       authorization: "Bearer ${OTLP_TOKEN}"
+    metrics:
+      temporality: delta        # cumulative | delta | lowmemory
+      pushInterval: 30s          # export interval (default 30s)
 ```
 
 These values configure the operator through the standard OpenTelemetry SDK environment variables, which you can also set directly (for example via `extraEnv`):
@@ -61,7 +62,7 @@ These values configure the operator through the standard OpenTelemetry SDK envir
 | `OTEL_EXPORTER_OTLP_HEADERS`                        | Comma-separated `key=value` headers (e.g. authentication).      | `authorization=Bearer abc123`           |
 | `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` | Aggregation temporality: `cumulative`, `delta`, or `lowmemory`. | `delta`                                 |
 | `OTEL_METRIC_EXPORT_INTERVAL`                       | Export interval in milliseconds.                                | `60000`                                 |
-| `OTEL_SERVICE_NAME`                                 | `service.name` resource attribute.                              | `spiceai-operator`                      |
+| `OTEL_SERVICE_NAME`                                 | `service.name` resource attribute (default `spice-k8s-operator`). | `spice-k8s-operator`                  |
 | `OTEL_RESOURCE_ATTRIBUTES`                          | Additional resource attributes as `key=value` pairs.            | `deployment.environment=prod`           |
 
 ### Choose the right temporality

--- a/enterprise/kubernetes/spicepodcluster.md
+++ b/enterprise/kubernetes/spicepodcluster.md
@@ -5,10 +5,10 @@ icon: circle-nodes
 
 # SpicepodCluster
 
-A `SpicepodCluster` (`spice.ai/v2beta1`) deploys a distributed query cluster with dedicated scheduler and executor nodes. The operator automatically manages mTLS certificate provisioning, child `SpicepodSet` resources, and cluster topology.
+A `SpicepodCluster` (`spice.ai/v2`) deploys a distributed query cluster with dedicated scheduler and executor nodes. The operator automatically manages mTLS certificate provisioning, child `SpicepodSet` resources, and cluster topology.
 
 {% hint style="info" %}
-`v2beta1` is the current schema. Legacy `spice.ai/v1alpha1` `SpicepodCluster` manifests continue to apply unchanged and are converted automatically. The main renames are `schedulerSetSpec` / `executorSetSpec` → `schedulerSpec` / `executorSpec`, plus the `status` certificate fields; see [Status](#status).
+`v2` is the current schema. Legacy `spice.ai/v1alpha1` `SpicepodCluster` manifests continue to apply unchanged and are converted automatically. The main renames are `schedulerSetSpec` / `executorSetSpec` → `schedulerSpec` / `executorSpec`, plus the `status` certificate fields; see [Status](#status).
 {% endhint %}
 
 ## Architecture
@@ -36,7 +36,7 @@ Schedulers coordinate query planning and partition assignment; executors perform
 ## Example
 
 ```yaml
-apiVersion: spice.ai/v2beta1
+apiVersion: spice.ai/v2
 kind: SpicepodCluster
 metadata:
   name: my-cluster

--- a/enterprise/kubernetes/spicepodcluster.md
+++ b/enterprise/kubernetes/spicepodcluster.md
@@ -5,11 +5,15 @@ icon: circle-nodes
 
 # SpicepodCluster
 
-A `SpicepodCluster` deploys a distributed query cluster with dedicated scheduler and executor nodes. The operator automatically manages mTLS certificate provisioning, child `SpicepodSet` resources, and cluster topology.
+A `SpicepodCluster` (`spice.ai/v2beta1`) deploys a distributed query cluster with dedicated scheduler and executor nodes. The operator automatically manages mTLS certificate provisioning, child `SpicepodSet` resources, and cluster topology.
+
+{% hint style="info" %}
+`v2beta1` is the current schema. Legacy `spice.ai/v1alpha1` `SpicepodCluster` manifests continue to apply unchanged and are converted automatically. The main renames are `schedulerSetSpec` / `executorSetSpec` → `schedulerSpec` / `executorSpec`, plus the `status` certificate fields; see [Status](#status).
+{% endhint %}
 
 ## Architecture
 
-```
+```text
              ┌─────────────────────┐
              │    Load Balancer    │
              └─────────────────────┘
@@ -32,13 +36,13 @@ Schedulers coordinate query planning and partition assignment; executors perform
 ## Example
 
 ```yaml
-apiVersion: spice.ai/v1alpha1
+apiVersion: spice.ai/v2beta1
 kind: SpicepodCluster
 metadata:
   name: my-cluster
   namespace: default
 spec:
-  schedulerSetSpec:
+  schedulerSpec:
     replicas: 1
     spicepod:
       version: v1
@@ -51,7 +55,7 @@ spec:
       limits:
         cpu: 500m
         memory: 512Mi
-  executorSetSpec:
+  executorSpec:
     replicas: 3
     resources:
       requests:
@@ -62,13 +66,15 @@ spec:
         memory: 2Gi
 ```
 
+Executors pull their Spicepod configuration from the scheduler, so no `spicepod` field is needed on `executorSpec`.
+
 ## Multi-Replica Schedulers
 
 For high availability, deploy multiple schedulers:
 
 ```yaml
 spec:
-  schedulerSetSpec:
+  schedulerSpec:
     replicas: 2
 ```
 
@@ -131,17 +137,20 @@ kubectl get pods -l spice.ai/cluster-role=executor
 
 ## Configuration Inheritance
 
-`SpicepodCluster` creates child `SpicepodSet` resources for schedulers and executors. Both `schedulerSetSpec` and `executorSetSpec` accept the same subset of [`SpicepodSet` fields](spicepodset.md): `image`, `httpPort`, `flightPort`, `metricsPort`, `replicas`, `resources`, `env`, `envFromSource`, `network`, `nodeAffinity`, `tolerations`, `volume`, `serviceAccount`, `annotations`, `labels`, `updateStrategy`, `probes`, `terminationGracePeriodSeconds`, and `cluster`.
+`SpicepodCluster` creates child `SpicepodSet` resources for schedulers and executors. Both `schedulerSpec` and `executorSpec` accept the common [`SpicepodSet` spec fields](spicepodset.md): `image`, `http`, `flight`, `metrics`, `replicas`, `resources`, `env`, `envFromSource`, `network`, `nodeAffinity`, `tolerations`, `volumeClaimTemplate`, `serviceAccount`, `annotations`, `labels`, `updateStrategy`, `terminationGracePeriodSeconds`, and a per-node `cluster` override.
 
-The `executorSetSpec` does **not** accept a `spicepod` field — executors fetch the Spicepod definition from the scheduler at startup via `GetAppDefinition`.
+Notable differences from a standalone `SpicepodSet`:
+
+- `executorSpec` does **not** accept `spicepod` or `probes` — executors fetch the Spicepod definition from the scheduler at startup via `GetAppDefinition` and run without the HTTP server that probes target.
+- The `service` toggle is not available on cluster node specs; the operator manages the headless Services required for mTLS and scheduler/executor discovery.
 
 ### Per-node `cluster` overrides
 
-The `cluster` field on `schedulerSetSpec` / `executorSetSpec` is a small subset (`NodeClusterConfig`) used to override cluster-internal addresses; the operator otherwise auto-populates cluster identity, role, mTLS, and scheduler discovery:
+The `cluster` field on `schedulerSpec` / `executorSpec` is a small subset (`NodeClusterConfig`) used to override cluster-internal addresses; the operator otherwise auto-populates cluster identity, role, mTLS, and scheduler discovery:
 
 ```yaml
 spec:
-  schedulerSetSpec:
+  schedulerSpec:
     cluster:
       bindAddress: "0.0.0.0:50052"
 ```
@@ -152,13 +161,13 @@ spec:
 kubectl get spicepodcluster my-cluster -o yaml
 ```
 
-| Field                       | Description                                                                |
-| --------------------------- | -------------------------------------------------------------------------- |
-| `rootCertificateReady`      | Whether the cluster's root CA has been generated.                          |
-| `rootSecretName`            | Secret holding the root CA certificate and private key.                    |
-| `rootExpiresAt`             | RFC 3339 expiration of the root CA.                                        |
-| `schedulerSpicepodsetName`  | Name of the child scheduler `SpicepodSet`.                                 |
-| `executorSpicepodsetName`   | Name of the child executor `SpicepodSet`.                                  |
-| `schedulerReadyReplicas`    | Ready scheduler replicas.                                                  |
-| `executorReadyReplicas`     | Ready executor replicas.                                                   |
-| `error`                     | Error message if certificate generation or reconciliation failed.          |
+| Field                       | Description                                                                               |
+| --------------------------- | ----------------------------------------------------------------------------------------- |
+| `rootCertificateReady`      | Whether the cluster's root CA has been generated.                                         |
+| `rootCertificateSecretName` | Secret holding the root CA certificate and private key.                                   |
+| `rootCertificateExpiresAt`  | RFC 3339 expiration of the root CA.                                                       |
+| `schedulerSpicepodsetName`  | Name of the child scheduler `SpicepodSet`.                                                |
+| `executorSpicepodsetName`   | Name of the child executor `SpicepodSet`.                                                 |
+| `schedulerReadyReplicas`    | Ready scheduler replicas.                                                                 |
+| `executorReadyReplicas`     | Ready executor replicas.                                                                  |
+| `conditions`                | Standard Kubernetes `Condition`s (`Ready`, `Paused`); supersede the legacy `error` field. |

--- a/enterprise/kubernetes/spicepodcluster.md
+++ b/enterprise/kubernetes/spicepodcluster.md
@@ -137,7 +137,7 @@ kubectl get pods -l spice.ai/cluster-role=executor
 
 ## Configuration Inheritance
 
-`SpicepodCluster` creates child `SpicepodSet` resources for schedulers and executors. Both `schedulerSpec` and `executorSpec` accept the common [`SpicepodSet` spec fields](spicepodset.md): `image`, `http`, `flight`, `metrics`, `replicas`, `resources`, `env`, `envFromSource`, `network`, `nodeAffinity`, `tolerations`, `volumeClaimTemplate`, `serviceAccount`, `annotations`, `labels`, `updateStrategy`, `terminationGracePeriodSeconds`, and a per-node `cluster` override.
+`SpicepodCluster` creates child `SpicepodSet` resources for schedulers and executors. Both `schedulerSpec` and `executorSpec` accept the common [`SpicepodSet` spec fields](spicepodset.md): `image`, `http`, `flight`, `metrics`, `replicas`, `resources`, `env`, `envFromSource`, `network`, `nodeAffinity`, `tolerations`, `volumeClaimTemplates`, `volumeMounts`, `serviceAccount`, `annotations`, `labels`, `updateStrategy`, `terminationGracePeriodSeconds`, and a per-node `cluster` override.
 
 Notable differences from a standalone `SpicepodSet`:
 

--- a/enterprise/kubernetes/spicepodset.md
+++ b/enterprise/kubernetes/spicepodset.md
@@ -107,19 +107,21 @@ The Spicepod YAML supports `${secrets:KEY}` references to Kubernetes Secret valu
 
 ## Persistent Storage
 
-Add a persistent volume to each pod replica with `volumeClaimTemplate`, which mirrors the upstream `PersistentVolumeClaimTemplate` shape. The operator creates a `PersistentVolumeClaim` as part of each `StatefulSet`, mounted at `/data`:
+Add persistent volumes to each pod replica with `volumeClaimTemplates`, a list whose entries mirror the upstream `PersistentVolumeClaimTemplate` shape. The operator creates a `PersistentVolumeClaim` per entry as part of each `StatefulSet`. The template named `data` (the name defaults to `data` when `metadata.name` is omitted) is auto-mounted at `/data` with no `volumeMounts` entry required; any other template must be paired with an explicit `volumeMounts` entry of the same name:
 
 ```yaml
 spec:
-  volumeClaimTemplate:
-    spec:
-      storageClassName: standard
-      resources:
-        requests:
-          storage: 10Gi
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        storageClassName: standard
+        resources:
+          requests:
+            storage: 10Gi
 ```
 
-The full PVC spec is available, including `accessModes`, `volumeMode`, and `selector`. Increasing `volumeClaimTemplate.spec.resources.requests.storage` triggers automatic PVC resizing, provided the `StorageClass` has `allowVolumeExpansion: true`.
+The full PVC spec is available, including `accessModes`, `volumeMode`, and `selector`. Increasing a template's `spec.resources.requests.storage` triggers automatic PVC resizing, provided the `StorageClass` has `allowVolumeExpansion: true`.
 
 {% hint style="warning" %}
 Volume shrinking is not supported. Decreasing the storage request has no effect on existing PVCs. Under the `BlueGreen` strategy, PVCs behave like ephemeral storage — each generation gets new PVCs, so volume data is not preserved across cutovers.
@@ -286,7 +288,7 @@ spec:
     team: data-platform
 ```
 
-Labels and annotations are `kebab-case`, and the operator's own keys are namespaced under `spice.ai/` (e.g. `spice.ai/app`, `spice.ai/spicepod`, `spice.ai/version`, `spice.ai/cluster`, `spice.ai/cluster-role`, `spice.ai/component`, `spice.ai/sidecar-injected`, `spice.ai/validation-level`). The admission controller **rejects** attempts to set these reserved keys on `spec.annotations` or `spec.labels`.
+Labels and annotations are `kebab-case`, and the operator's own keys are namespaced under `spice.ai/`. Reserved labels are `spice.ai/app`, `spice.ai/spicepod`, `spice.ai/version`, `spice.ai/cluster`, `spice.ai/cluster-role`, `spice.ai/cluster-mtls`, and `spice.ai/component`; reserved annotations are `spice.ai/sidecar-injected`, `spice.ai/observed-generation`, and `spice.ai/validation-level`. The admission controller **rejects** attempts to set these reserved keys on `spec.annotations` or `spec.labels`.
 
 {% hint style="info" %}
 To annotate only the ServiceAccount (e.g. for IRSA), use `serviceAccount.annotations` — those are not propagated to other resources.
@@ -330,7 +332,7 @@ spec:
 
 ## Crashloop Protection
 
-The operator monitors pods for repeated failures, combining two signals: accumulated dead pods (Failed + Succeeded) and pod failure events (`BackOff`, `Killing`, `Evicted`, `OOMKilling`, `Failed`). When a `SpicepodSet` exceeds the configured threshold, the operator pauses the workload (`replicas → 0`), sets `status.pauseReason = CrashLooping`, emits a Warning event, and surfaces the state through `status.conditions`. To resume, fix the configuration and set `replicas` back to the desired count.
+The operator monitors pods for repeated failures, combining two signals: accumulated dead pods (Failed + Succeeded) and pod failure events (`BackOff`, `Evicted`, `OOMKilling`, `Failed`). When a `SpicepodSet` exceeds the configured threshold, the operator pauses the workload (`replicas → 0`), sets `status.pauseReason = CrashLooping`, emits a Warning event, and surfaces the state through `status.conditions`. To resume, fix the configuration and set `replicas` back to the desired count.
 
 Configure the threshold via the operator CLI flag `--pause-crashlooping-pods-threshold` (Helm value `pauseCrashloopingPodsThreshold`). The binary defaults to `10`, but the chart ships `0` (crashloop protection **disabled**) by default — set a positive integer to enable it.
 
@@ -396,8 +398,8 @@ For operator self-telemetry (controller reconcile counts/durations, Kubernetes A
 | `spiceai_image_tag`                                  | `image.tag`                                                               |
 | `httpPort` / `flightPort` / `metricsPort`            | `http.port` / `flight.port` / `metrics.port`                              |
 | `enableService`                                      | `service.enabled`                                                         |
-| `volume.storageClassName` / `volume.storageRequests` | `volumeClaimTemplate.spec.{storageClassName, resources.requests.storage}` |
+| `volume.storageClassName` / `volume.storageRequests` | `volumeClaimTemplates[].spec.{storageClassName, resources.requests.storage}` |
 | `update_strategy`                                    | `updateStrategy` (camelCase; `Parallel` removed)                          |
-| `instantRollback` + `spice.ai/rollback` annotation   | `standbyVersion` (SHA-based; re-apply previous spec)                      |
+| `instantRollback`                                    | `standbyVersion` (SHA-based; re-apply previous spec)                      |
 
 All status timestamps are now RFC 3339 strings, and labels/annotations are `kebab-case` with the legacy `app` label namespaced as `spice.ai/app`. For the full field-by-field guide, see the [operator upgrade guide](https://github.com/spicehq/spice-k8s-operator).

--- a/enterprise/kubernetes/spicepodset.md
+++ b/enterprise/kubernetes/spicepodset.md
@@ -5,18 +5,18 @@ icon: layer-group
 
 # SpicepodSet
 
-A `SpicepodSet` (`spice.ai/v2beta1`) deploys and manages one or more Spicepod replicas. The operator handles the full lifecycle: creating the workload, rolling updates, volume management, health monitoring, and crashloop protection.
+A `SpicepodSet` (`spice.ai/v2`) deploys and manages one or more Spicepod replicas. The operator handles the full lifecycle: creating the workload, rolling updates, volume management, health monitoring, and crashloop protection.
 
 Every `SpicepodSet` is deployed as one or more `StatefulSet`s — one per replica, each with an ordinal suffix — giving every pod a stable identity, ordered startup, and a predictable network hostname, even for single-replica workloads. Rollouts, `BlueGreen` cutovers, and standby retention are all expressed as parallel, suffixed `StatefulSet`s.
 
 {% hint style="info" %}
-`v2beta1` is the current schema. Legacy `spice.ai/v1` `SpicepodSet` manifests continue to apply unchanged and are losslessly converted by the operator, and pre-existing v0.x `Deployment`-based workloads are grandfathered. See [Migrating from `spice.ai/v1`](#migrating-from-spiceaiv1) for the field-by-field mapping.
+`v2` is the current schema. Legacy `spice.ai/v1` `SpicepodSet` manifests continue to apply unchanged and are losslessly converted by the operator, and pre-existing v0.x `Deployment`-based workloads are grandfathered. See [Migrating from `spice.ai/v1`](#migrating-from-spiceaiv1) for the field-by-field mapping.
 {% endhint %}
 
 ## Minimal Example
 
 ```yaml
-apiVersion: spice.ai/v2beta1
+apiVersion: spice.ai/v2
 kind: SpicepodSet
 metadata:
   name: my-spicepod
@@ -387,9 +387,9 @@ For operator self-telemetry (controller reconcile counts/durations, Kubernetes A
 
 ## Migrating from `spice.ai/v1`
 
-`v2beta1` renames several fields to follow standard Kubernetes API conventions. Existing `spice.ai/v1` resources keep working and are converted automatically, but manifests authored natively against `v2beta1` should adopt the new shape.
+`v2` renames several fields to follow standard Kubernetes API conventions. Existing `spice.ai/v1` resources keep working and are converted automatically, but manifests authored natively against `v2` should adopt the new shape.
 
-| `spice.ai/v1`                                        | `spice.ai/v2beta1`                                                        |
+| `spice.ai/v1`                                        | `spice.ai/v2`                                                             |
 | ---------------------------------------------------- | ------------------------------------------------------------------------- |
 | `spicepod: \|` (string-encoded YAML)                 | `spicepod:` (structured object)                                           |
 | `spiceai_image_registry` / `spiceai_image_name`      | `image.repository` (full path)                                            |

--- a/enterprise/kubernetes/spicepodset.md
+++ b/enterprise/kubernetes/spicepodset.md
@@ -5,17 +5,18 @@ icon: layer-group
 
 # SpicepodSet
 
-A `SpicepodSet` (`spice.ai/v1`) deploys and manages one or more Spicepod replicas. The operator handles the full lifecycle: creating the workload, rolling updates, volume management, health monitoring, and crashloop protection.
+A `SpicepodSet` (`spice.ai/v2beta1`) deploys and manages one or more Spicepod replicas. The operator handles the full lifecycle: creating the workload, rolling updates, volume management, health monitoring, and crashloop protection.
 
-The operator chooses the underlying workload type adaptively:
+Every `SpicepodSet` is deployed as one or more `StatefulSet`s — one per replica, each with an ordinal suffix — giving every pod a stable identity, ordered startup, and a predictable network hostname, even for single-replica workloads. Rollouts, `BlueGreen` cutovers, and standby retention are all expressed as parallel, suffixed `StatefulSet`s.
 
-- A single `Deployment` for the simple case (no `volume`, no `cluster`, `replicas <= 1`).
-- Per-replica `StatefulSet`s when `volume`, `cluster`, or `replicas > 1` is configured, providing stable pod identities and ordered startup.
+{% hint style="info" %}
+`v2beta1` is the current schema. Legacy `spice.ai/v1` `SpicepodSet` manifests continue to apply unchanged and are losslessly converted by the operator, and pre-existing v0.x `Deployment`-based workloads are grandfathered. See [Migrating from `spice.ai/v1`](#migrating-from-spiceaiv1) for the field-by-field mapping.
+{% endhint %}
 
 ## Minimal Example
 
 ```yaml
-apiVersion: spice.ai/v1
+apiVersion: spice.ai/v2beta1
 kind: SpicepodSet
 metadata:
   name: my-spicepod
@@ -28,44 +29,47 @@ spec:
     version: v1
 ```
 
-The `spicepod` field accepts the inline Spicepod definition (datasets, catalogs, models, views, etc.) and is preserved as-is by the operator.
+The `spicepod` field is a structured object holding the inline Spicepod definition (datasets, catalogs, models, views, etc.) and is preserved as-is by the operator. It is stored in a `ConfigMap` and mounted into each pod; changing it triggers a rollout.
 
 ## Container Image
 
 ```yaml
 spec:
   image:
-    registry: 709825985650.dkr.ecr.us-east-1.amazonaws.com
-    name: spice-ai/spiceai-enterprise-byol
-    tag: latest-models
+    repository: 709825985650.dkr.ecr.us-east-1.amazonaws.com/spice-ai/spiceai-enterprise-plan
+    tag: 2.0.0-enterprise-models
     pullPolicy: IfNotPresent          # Always | Never | IfNotPresent
     pullSecret: my-pull-secret
 ```
 
-| Field        | Default                                     | Description                                                              |
-| ------------ | ------------------------------------------- | ------------------------------------------------------------------------ |
-| `tag`        | `latest-models`                             | Image tag.                                                               |
-| `name`       | `spiceai/spiceai`                           | Image name.                                                              |
-| `registry`   | Docker Hub                                  | Image registry.                                                          |
-| `pullPolicy` | `Always` for `:latest`, else `IfNotPresent` | Image pull policy.                                                       |
-| `pullSecret` | —                                           | Name of a Kubernetes Secret holding credentials for a private registry.  |
+| Field        | Default                                     | Description                                                             |
+| ------------ | ------------------------------------------- | ----------------------------------------------------------------------- |
+| `repository` | `…/spice-ai/spiceai-enterprise-plan`        | Full image path (registry + name).                                      |
+| `tag`        | `2.0.0-enterprise-models`                   | Image tag.                                                              |
+| `pullPolicy` | `Always` for `:latest`, else `IfNotPresent` | Image pull policy (`Always` \| `Never` \| `IfNotPresent`).              |
+| `pullSecret` | —                                           | Name of a Kubernetes Secret holding credentials for a private registry. |
+
+`repository` is the full registry + name path. The enterprise default is pulled from the AWS Marketplace ECR registry — provide credentials via `pullSecret`. To use a public build instead, set e.g. `repository: spiceai/spiceai` (Docker Hub) or `repository: ghcr.io/spiceai/spiceai`.
 
 ## Ports
 
 ```yaml
 spec:
-  httpPort: 8090
-  flightPort: 50051
-  metricsPort: 9090
+  http:
+    port: 8090
+  flight:
+    port: 50051
+  metrics:
+    port: 9090
 ```
 
-| Field         | Default | Description                |
-| ------------- | ------- | -------------------------- |
-| `httpPort`    | `8090`  | HTTP API port.             |
-| `flightPort`  | `50051` | Apache Arrow Flight port.  |
-| `metricsPort` | `9090`  | Prometheus metrics port.   |
+| Field          | Default | Description               |
+| -------------- | ------- | ------------------------- |
+| `http.port`    | `8090`  | HTTP API port.            |
+| `flight.port`  | `50051` | Apache Arrow Flight port. |
+| `metrics.port` | `9090`  | Prometheus metrics port.  |
 
-The Service exposes fixed ports `8080` (HTTP), `50051` (Flight), and `9090` (metrics) and maps `targetPort` to the configured Spiced ports above.
+These configure what the Spiced container listens on. The Service exposes fixed ports `8080` (HTTP), `50051` (Flight), and `9090` (metrics) and maps `targetPort` to the configured Spiced ports above. Health probes target `http.port`.
 
 ## Resources
 
@@ -99,22 +103,27 @@ spec:
         name: my-secret
 ```
 
+The Spicepod YAML supports `${secrets:KEY}` references to Kubernetes Secret values. Inject the backing Secret with `envFromSource` so the value is resolvable inside the pod at runtime.
+
 ## Persistent Storage
 
-Enable persistent volumes with automatic resizing:
+Add a persistent volume to each pod replica with `volumeClaimTemplate`, which mirrors the upstream `PersistentVolumeClaimTemplate` shape. The operator creates a `PersistentVolumeClaim` as part of each `StatefulSet`, mounted at `/data`:
 
 ```yaml
 spec:
-  volume:
-    storageClassName: standard
-    storageRequests: 10Gi
+  volumeClaimTemplate:
+    spec:
+      storageClassName: standard
+      resources:
+        requests:
+          storage: 10Gi
 ```
 
-{% hint style="warning" %}
-Volume shrinking is not supported. Decreasing `storageRequests` has no effect on existing PVCs.
-{% endhint %}
+The full PVC spec is available, including `accessModes`, `volumeMode`, and `selector`. Increasing `volumeClaimTemplate.spec.resources.requests.storage` triggers automatic PVC resizing, provided the `StorageClass` has `allowVolumeExpansion: true`.
 
-When `volume` is configured, the operator deploys per-replica `StatefulSet`s with `PersistentVolumeClaim`s. Increasing `storageRequests` triggers automatic PVC resizing.
+{% hint style="warning" %}
+Volume shrinking is not supported. Decreasing the storage request has no effect on existing PVCs. Under the `BlueGreen` strategy, PVCs behave like ephemeral storage — each generation gets new PVCs, so volume data is not preserved across cutovers.
+{% endhint %}
 
 ## Service Account
 
@@ -141,11 +150,11 @@ spec:
       eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/spice-ai-role
 ```
 
-| Field         | Default            | Description                                                                                    |
-| ------------- | ------------------ | ---------------------------------------------------------------------------------------------- |
-| `enabled`     | `false`            | Whether to use a ServiceAccount.                                                               |
-| `create`      | `false`            | Whether to create a new ServiceAccount. If `false`, set `name` to reference an existing one.   |
-| `name`        | `SpicepodSet` name | ServiceAccount name; required when `create: false`.                                            |
+| Field         | Default            | Description                                                                                       |
+| ------------- | ------------------ | ------------------------------------------------------------------------------------------------- |
+| `enabled`     | `false`            | Whether to use a ServiceAccount.                                                                  |
+| `create`      | `false`            | Whether to create a new ServiceAccount. If `false`, set `name` to reference an existing one.      |
+| `name`        | `SpicepodSet` name | ServiceAccount name; required when `create: false`.                                               |
 | `annotations` | —                  | Annotations applied **only** to the ServiceAccount (ideal for IRSA `eks.amazonaws.com/role-arn`). |
 
 ## Update Strategies
@@ -156,12 +165,11 @@ spec:
     type: RollingOrdered    # default
 ```
 
-| Strategy                 | Behavior                                                                                                                            |
-| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
-| **`RollingOrdered`** (default) | Updates pods one at a time in ordinal order, waiting for each to become Ready before proceeding.                          |
-| **`RollingParallel`**    | Updates pods in parallel. Set `maxUnavailable` to bound concurrent unavailable pods.                                                |
-| **`Parallel`**           | Updates all pods simultaneously with no availability constraints.                                                                   |
-| **`BlueGreen`**          | Brings up a parallel `StatefulSet` for the new generation, then atomically switches Service traffic once **all** new-generation pods are Ready. PVCs are ephemeral across generations. |
+| Strategy                       | Behavior                                                                                                                                                                                                                          |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`RollingOrdered`** (default) | Updates pods one at a time in ordinal order, waiting for each to become Ready before proceeding.                                                                                                                                  |
+| **`RollingParallel`**          | Updates pods in parallel, keeping at least one available. Set `maxUnavailable` to bound concurrent unavailable pods.                                                                                                              |
+| **`BlueGreen`**                | Brings up a complete parallel set of `StatefulSet`s for the new generation, then atomically switches the Service to it once the new generation is Ready and tears down the old generation. PVCs are ephemeral across generations. |
 
 ```yaml
 spec:
@@ -172,42 +180,42 @@ spec:
     minReadyForCutover: 3   # optional
 ```
 
+{% hint style="info" %}
+The legacy `Parallel` strategy has been **removed**. Existing resources that specify `Parallel` are converted to the default `RollingOrdered`. Use `RollingParallel` with `maxUnavailable` for concurrent updates.
+{% endhint %}
+
 ### `minReadyForCutover`
 
-Switches the Service to the new generation as soon as `minReadyForCutover` new-generation pods are Ready, instead of waiting for all of them.
+Switches the Service to the new generation as soon as `minReadyForCutover` new-generation pods are Ready, instead of waiting for all of them. This is useful when the load profile is satisfied by fewer than the full replica count and a faster switchover is preferable to running at peak capacity for the whole rollout.
 
-- **For `BlueGreen` and instant-rollback**: switches the version-pinned Service selector and promotes `status.activeVersion` early.
+- **For `BlueGreen` and instant rollback**: switches the version-pinned Service selector and promotes `status.activeVersion` early.
 - **For `RollingOrdered` / `RollingParallel`**: causes the Service object to be created earlier in the rollout (selector is not version-pinned, so traffic is already routed to all matching Ready pods once the Service exists).
-- **Ignored** for `Parallel`. A value of `0` is treated as unset. Values larger than `replicas` collapse to "wait for all".
+- A value of `0` is treated as unset. Values larger than `replicas` collapse to "wait for all".
 
-## Instant Rollback
+## Standby Versions and Instant Rollback
 
-Retain the previous-generation pods after a rollout so traffic can be cut back to them instantly without rolling pods.
+Retain the previous-generation pods after a rollout so traffic can be cut back to them instantly, without waiting for pods to reschedule.
 
 ```yaml
 spec:
   updateStrategy:
     type: BlueGreen
-  instantRollback:
+  standbyVersion:
     enabled: true
     retentionPeriodSeconds: 900   # default 15 minutes
 ```
 
-After a successful rollout, set the rollback annotation on the `SpicepodSet` to swap traffic back to the standby:
+When `standbyVersion.enabled: true`, the previous version's workload is retained for `retentionPeriodSeconds` after a successful rollout. The operator tracks a content-based SHA of the deployment-affecting spec fields in the `spice.ai/version` label and exposes it as `status.activeVersion` / `status.standbyVersion`.
 
-```bash
-kubectl annotate spicepodset my-spicepod spice.ai/rollback=true --overwrite
-```
-
-The operator switches the Service to the standby pods, clears the annotation, and tracks `status.activeVersion` / `status.standbyVersion` / `status.standbyExpiresAt`. Standby pods are torn down after `retentionPeriodSeconds` if no rollback occurs.
+**To roll back, re-apply the previous `spec`** (e.g. `helm rollback`, `kubectl apply` of an earlier manifest, or a Git revert). The operator detects that the incoming version SHA matches the retained standby, then swaps the active and standby workloads in place — patching the version-pinned Service selector immediately, without restarting pods. Non-deployment changes (such as editing `retentionPeriodSeconds` or the update strategy) do not create a new version or undo a rollback.
 
 {% hint style="info" %}
-Combine `instantRollback` with `BlueGreen` for the canonical zero-downtime production rollout pattern.
+Because the trigger is the spec SHA itself, instant rollback is GitOps-compatible (ArgoCD / Flux): reverting the manifest in Git is sufficient, with no operator-owned annotation to round-trip and no `ignoreDifferences` configuration required. Combine `standbyVersion` with `BlueGreen` for the canonical zero-downtime production rollout pattern.
 {% endhint %}
 
 ## Scaling and Pausing
 
-Set `replicas: 0` to pause the workload while retaining supporting resources (Service, ConfigMap, NetworkPolicy, ServiceAccount):
+Set `replicas: 0` to pause the workload while retaining supporting resources (Service, ConfigMap, ServiceAccount, and any user-supplied NetworkPolicy):
 
 ```yaml
 spec:
@@ -216,18 +224,11 @@ spec:
 
 ## Network and DNS
 
-Egress, ingress, DNS policy, and DNS config are nested under `network`:
+A `NetworkPolicy` is **opt-in**: the operator only creates one when you supply `network.ingress` and/or `network.egress`, and it writes those rules **verbatim** — no implicit operator-namespace ingress, DNS egress, or cluster-peer rules are appended. If neither field is set, no `NetworkPolicy` is created and pod traffic follows the cluster default.
 
 ```yaml
 spec:
   network:
-    egress:
-      - to:
-          - ipBlock:
-              cidr: 10.0.0.0/8
-        ports:
-          - protocol: TCP
-            port: 443
     ingress:
       - from:
           - namespaceSelector:
@@ -235,7 +236,25 @@ spec:
                 name: my-namespace
         ports:
           - protocol: TCP
-            port: 8090
+            port: 8080
+    egress:
+      # Application traffic.
+      - to:
+          - ipBlock:
+              cidr: 10.0.0.0/8
+        ports:
+          - protocol: TCP
+            port: 443
+      # DNS — required in most clusters; the operator no longer adds this for you.
+      - to:
+          - namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: kube-system
+        ports:
+          - protocol: UDP
+            port: 53
+          - protocol: TCP
+            port: 53
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -244,16 +263,19 @@ spec:
         - my-domain.local
 ```
 
+The validating admission webhook **warns** when `network.egress` is set without a DNS (UDP/TCP 53) rule, and **rejects** cluster-mode workloads whose policy omits a peer rule selecting `spice.ai/cluster=<name>`. Adjust strictness with the `spice.ai/validation-level` annotation (`err` / `warn` / `off`).
+
 Disable the Service entirely:
 
 ```yaml
 spec:
-  enableService: false
+  service:
+    enabled: false
 ```
 
 ## Annotations and Labels
 
-Updating `annotations` or `labels` triggers a full pod rollout, even when no other configuration has changed:
+`annotations` and `labels` are propagated to **all** resources the operator creates (StatefulSets, Service, ConfigMap, etc.). Updating either triggers a full pod rollout, even when no other configuration has changed — a convenient way to force a restart:
 
 ```yaml
 spec:
@@ -264,7 +286,11 @@ spec:
     team: data-platform
 ```
 
-Operator-reserved keys (e.g. `spice.ai/app`, `spice.ai/spicepod`, `spice.ai/version`, `spice.ai/cluster`, `spice.ai/cluster-role`, `spice.ai/cluster-mtls`, `spice.ai/component`, `spice.ai/observed-generation`, `spice.ai/rollback`, `spice.ai/sidecar-injected`, `spice.ai/validation-level`) are stripped from user-supplied annotations/labels.
+Labels and annotations are `kebab-case`, and the operator's own keys are namespaced under `spice.ai/` (e.g. `spice.ai/app`, `spice.ai/spicepod`, `spice.ai/version`, `spice.ai/cluster`, `spice.ai/cluster-role`, `spice.ai/component`, `spice.ai/sidecar-injected`, `spice.ai/validation-level`). The admission controller **rejects** attempts to set these reserved keys on `spec.annotations` or `spec.labels`.
+
+{% hint style="info" %}
+To annotate only the ServiceAccount (e.g. for IRSA), use `serviceAccount.annotations` — those are not propagated to other resources.
+{% endhint %}
 
 ## Health Probes
 
@@ -304,24 +330,42 @@ spec:
 
 ## Crashloop Protection
 
-The operator monitors pods for repeated failures. When a `SpicepodSet` accumulates more dead pod observations than the threshold (default: `10`), the operator pauses the workload (`replicas → 0`) and records a `pauseReason` of `CrashLooping` in status. Configure via the operator CLI flag `--pause-crashlooping-pods-threshold` (`0` disables).
+The operator monitors pods for repeated failures, combining two signals: accumulated dead pods (Failed + Succeeded) and pod failure events (`BackOff`, `Killing`, `Evicted`, `OOMKilling`, `Failed`). When a `SpicepodSet` exceeds the configured threshold, the operator pauses the workload (`replicas → 0`), sets `status.pauseReason = CrashLooping`, emits a Warning event, and surfaces the state through `status.conditions`. To resume, fix the configuration and set `replicas` back to the desired count.
+
+Configure the threshold via the operator CLI flag `--pause-crashlooping-pods-threshold` (Helm value `pauseCrashloopingPodsThreshold`). The binary defaults to `10`, but the chart ships `0` (crashloop protection **disabled**) by default — set a positive integer to enable it.
+
+## Admission Validation
+
+A validating admission webhook checks each `SpicepodSet` at apply time rather than at reconcile time. Validations include:
+
+- **Spicepod schema** — the `spicepod` payload is parsed against the schema selected by its inline `version:` field, with errors identifying the offending fields.
+- **NetworkPolicy invariants** — warns when `network.egress` omits a DNS rule; rejects cluster-mode resources missing an intra-cluster peer rule.
+- **Reserved labels/annotations** — rejects operator-reserved keys on `spec.labels` / `spec.annotations`, and enforces label length limits.
+- **Volume storage class** — validates that the requested `storageClassName` exists.
+
+The default strictness is set operator-wide with `--admission-policy` (Helm `admissionPolicy`): `err` (reject, default), `warn` (allow with a warning), or `off`. Override per-resource with the `spice.ai/validation-level` annotation (`err` / `warn` / `off`).
 
 ## Status
 
 Useful fields on `status`:
 
-| Field                             | Description                                                                                  |
-| --------------------------------- | -------------------------------------------------------------------------------------------- |
-| `replicas`                        | Formatted replica state for `kubectl` display, e.g. `2/5`.                                   |
-| `readyReplicas` / `totalReplicas` | Numeric replica counts.                                                                      |
-| `role`                            | `<none>`, `scheduler`, or `executor`.                                                        |
-| `pauseReason`                     | Set when paused (e.g. `CrashLooping`).                                                       |
-| `activeVersion`                   | Spec SHA of the version currently receiving traffic (instant rollback).                      |
-| `standbyVersion`                  | Spec SHA of the standby retained for instant rollback.                                       |
-| `standbyExpiresAt`                | Epoch seconds when the standby pods will be reclaimed.                                       |
-| `conditions`                      | Standard Kubernetes `Condition`s describing reconciliation state.                            |
+| Field                             | Description                                                       |
+| --------------------------------- | ----------------------------------------------------------------- |
+| `replicas`                        | Formatted replica state for `kubectl` display, e.g. `2/5`.        |
+| `readyReplicas` / `totalReplicas` | Numeric replica counts.                                           |
+| `role`                            | `<none>`, `scheduler`, or `executor`.                             |
+| `pauseReason`                     | Set when paused (e.g. `CrashLooping`).                            |
+| `activeVersion`                   | Spec SHA of the version currently receiving traffic.              |
+| `standbyVersion`                  | Spec SHA of the standby retained for instant rollback.            |
+| `standbyExpiresAt`                | RFC 3339 timestamp when the standby pods will be reclaimed.       |
+| `conditions`                      | Standard Kubernetes `Condition`s, including `Ready` and `Paused`. |
+
+The `conditions` array makes a `SpicepodSet` compatible with native Kubernetes tooling:
 
 ```bash
+kubectl wait spicepodset/my-spicepod --for=condition=Ready
+kubectl wait spicepodset/my-spicepod --for=condition=Paused=False
+
 kubectl get spicepodset
 # NAME          READY   ROLE     AGE   LAST UPDATED
 # my-spicepod   3/3     <none>   2d    1m
@@ -338,3 +382,22 @@ telemetryProperties:
   team: data-platform
   region: us-west-2
 ```
+
+For operator self-telemetry (controller reconcile counts/durations, Kubernetes API latencies, certificate expiry) over Prometheus and OTLP, see [Operator Metrics](metrics.md).
+
+## Migrating from `spice.ai/v1`
+
+`v2beta1` renames several fields to follow standard Kubernetes API conventions. Existing `spice.ai/v1` resources keep working and are converted automatically, but manifests authored natively against `v2beta1` should adopt the new shape.
+
+| `spice.ai/v1`                                        | `spice.ai/v2beta1`                                                        |
+| ---------------------------------------------------- | ------------------------------------------------------------------------- |
+| `spicepod: \|` (string-encoded YAML)                 | `spicepod:` (structured object)                                           |
+| `spiceai_image_registry` / `spiceai_image_name`      | `image.repository` (full path)                                            |
+| `spiceai_image_tag`                                  | `image.tag`                                                               |
+| `httpPort` / `flightPort` / `metricsPort`            | `http.port` / `flight.port` / `metrics.port`                              |
+| `enableService`                                      | `service.enabled`                                                         |
+| `volume.storageClassName` / `volume.storageRequests` | `volumeClaimTemplate.spec.{storageClassName, resources.requests.storage}` |
+| `update_strategy`                                    | `updateStrategy` (camelCase; `Parallel` removed)                          |
+| `instantRollback` + `spice.ai/rollback` annotation   | `standbyVersion` (SHA-based; re-apply previous spec)                      |
+
+All status timestamps are now RFC 3339 strings, and labels/annotations are `kebab-case` with the legacy `app` label namespaced as `spice.ai/app`. For the full field-by-field guide, see the [operator upgrade guide](https://github.com/spicehq/spice-k8s-operator).

--- a/enterprise/kubernetes/user-guide.md
+++ b/enterprise/kubernetes/user-guide.md
@@ -1,0 +1,359 @@
+---
+description: Step-by-step guide to deploying and operating Spice.ai workloads with the Kubernetes Operator.
+icon: book-open
+---
+
+# User Guide
+
+This guide walks through deploying and operating Spice.ai on Kubernetes with the operator — from installing the controller to configuring storage, networking, rollouts, scaling, and observability. For exhaustive field references, see [SpicepodSet](spicepodset.md) and [SpicepodCluster](spicepodcluster.md).
+
+{% hint style="info" %}
+All manifests below use the current `spice.ai/v2beta1` API version. Existing `spice.ai/v1` / `spice.ai/v1alpha1` manifests continue to apply and are converted automatically — see [Migrating from `spice.ai/v1`](spicepodset.md#migrating-from-spiceaiv1).
+{% endhint %}
+
+## Prerequisites
+
+- Kubernetes 1.33+
+- Helm 3.x
+- `kubectl` configured for your cluster
+- Access to a Spice runtime image (the enterprise image is pulled from the AWS Marketplace ECR registry; a [pull secret](#use-a-private-registry) is required)
+
+## 1. Install the operator
+
+The operator is distributed as an OCI Helm chart. Subscribe to the [AWS Marketplace](../deployment/aws-marketplace.md) listing, authenticate to the Marketplace ECR registry, then install into its own namespace:
+
+```bash
+helm install spiceai-operator \
+  oci://709825985650.dkr.ecr.us-east-1.amazonaws.com/spice-ai/charts/spiceai-operator \
+  --namespace spiceai-operator-system --create-namespace
+```
+
+The chart installs the `SpicepodSet` and `SpicepodCluster` CRDs by default (`installCRDs: true`). Verify the controller is running:
+
+```bash
+kubectl -n spiceai-operator-system get pods
+kubectl get crds | grep spice.ai
+```
+
+See the [Overview](README.md#helm-values) for the full list of Helm values.
+
+## 2. Deploy your first Spicepod
+
+A `SpicepodSet` is the simplest way to run a Spicepod. Create `spicepodset.yaml`:
+
+```yaml
+apiVersion: spice.ai/v2beta1
+kind: SpicepodSet
+metadata:
+  name: my-spicepod
+  namespace: default
+spec:
+  replicas: 1
+  spicepod:
+    name: my-spicepod
+    kind: Spicepod
+    version: v1
+    # datasets, catalogs, models, views, ... go here
+```
+
+Apply it and watch it come up:
+
+```bash
+kubectl apply -f spicepodset.yaml
+kubectl get spicepodset my-spicepod -w
+# NAME          READY   ROLE     AGE   LAST UPDATED
+# my-spicepod   1/1     <none>   30s   5s
+```
+
+Each `SpicepodSet` is deployed as one or more `StatefulSet`s — one per replica, each with an ordinal suffix — so every pod has a stable identity and predictable DNS name, even with a single replica. The `spicepod` object is stored in a `ConfigMap` and mounted into each pod; editing it triggers a rollout.
+
+Port-forward and query the runtime:
+
+```bash
+kubectl port-forward svc/my-spicepod 8080:8080
+curl http://localhost:8080/health
+```
+
+## 3. Configure the workload
+
+The sections below cover the most common configuration tasks. Each maps to a field on `spec`; see the [SpicepodSet reference](spicepodset.md) for every option.
+
+### Set the container image
+
+```yaml
+spec:
+  image:
+    repository: 709825985650.dkr.ecr.us-east-1.amazonaws.com/spice-ai/spiceai-enterprise-plan
+    tag: 2.0.0-enterprise-models
+    pullPolicy: IfNotPresent
+```
+
+`repository` is the full registry + name path. To use a public build instead, set `repository: spiceai/spiceai` (Docker Hub) or `repository: ghcr.io/spiceai/spiceai`.
+
+#### Use a private registry
+
+Provide credentials with a pull secret:
+
+```bash
+kubectl create secret docker-registry spice-pull-secret \
+  --docker-server=709825985650.dkr.ecr.us-east-1.amazonaws.com \
+  --docker-username=AWS --docker-password="$(aws ecr get-login-password)"
+```
+
+```yaml
+spec:
+  image:
+    repository: 709825985650.dkr.ecr.us-east-1.amazonaws.com/spice-ai/spiceai-enterprise-plan
+    tag: 2.0.0-enterprise-models
+    pullSecret: spice-pull-secret
+```
+
+### Configure ports
+
+```yaml
+spec:
+  http:
+    port: 8090
+  flight:
+    port: 50051
+  metrics:
+    port: 9090
+```
+
+These set what the Spiced container listens on. The managed `Service` always exposes fixed ports `8080` (HTTP), `50051` (Flight), and `9090` (metrics), mapping `targetPort` to the configured Spiced ports above.
+
+### Request CPU and memory
+
+```yaml
+spec:
+  resources:
+    requests:
+      cpu: 200m
+      memory: 1Gi
+    limits:
+      cpu: "2"
+      memory: 4Gi
+```
+
+### Inject environment variables and secrets
+
+```yaml
+spec:
+  env:
+    - name: SPICE_LOG_LEVEL
+      value: debug
+    - name: MY_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: my-secret
+          key: api-key
+  envFromSource:
+    - secretRef:
+        name: my-secret
+```
+
+The Spicepod YAML supports `${secrets:KEY}` references to Kubernetes Secret values. Inject the backing Secret with `envFromSource` so the value resolves inside the pod at runtime.
+
+### Add persistent storage
+
+Attach a per-replica volume with `volumeClaimTemplate`; the operator creates a `PersistentVolumeClaim` per `StatefulSet`, mounted at `/data`:
+
+```yaml
+spec:
+  volumeClaimTemplate:
+    spec:
+      storageClassName: standard
+      resources:
+        requests:
+          storage: 10Gi
+```
+
+Increasing the storage request triggers automatic PVC resizing when the `StorageClass` has `allowVolumeExpansion: true`. Shrinking is not supported.
+
+### Use a service account (IRSA)
+
+```yaml
+spec:
+  serviceAccount:
+    enabled: true
+    create: true
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/spice-ai-role
+```
+
+Set `create: false` and `name:` to reuse an existing ServiceAccount.
+
+### Restrict network traffic
+
+A `NetworkPolicy` is **opt-in** — the operator only creates one when you supply `network.ingress` and/or `network.egress`, and writes those rules verbatim. No implicit DNS, operator-namespace, or cluster-peer rules are added, so include a DNS egress rule yourself:
+
+```yaml
+spec:
+  network:
+    egress:
+      - to:
+          - namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: kube-system
+        ports:
+          - protocol: UDP
+            port: 53
+          - protocol: TCP
+            port: 53
+```
+
+The admission webhook warns when egress omits a DNS rule. See [Network and DNS](spicepodset.md#network-and-dns) for the full schema.
+
+### Choose an update strategy
+
+```yaml
+spec:
+  replicas: 5
+  updateStrategy:
+    type: RollingParallel   # RollingOrdered (default) | RollingParallel | BlueGreen
+    maxUnavailable: 2
+```
+
+- **`RollingOrdered`** (default) — one pod at a time, waiting for Ready.
+- **`RollingParallel`** — parallel updates bounded by `maxUnavailable`.
+- **`BlueGreen`** — brings up a full parallel generation, then atomically switches the Service.
+
+The legacy `Parallel` strategy has been removed; resources specifying it are converted to `RollingOrdered`.
+
+### Enable standby versions and instant rollback
+
+Retain the previous generation after a rollout so traffic can be cut back instantly:
+
+```yaml
+spec:
+  updateStrategy:
+    type: BlueGreen
+  standbyVersion:
+    enabled: true
+    retentionPeriodSeconds: 900
+```
+
+To roll back, **re-apply the previous `spec`** (`helm rollback`, `kubectl apply` of an earlier manifest, or a Git revert). Because the trigger is a content-based SHA of the spec, rollback is GitOps-compatible with ArgoCD and Flux — no operator-owned annotation to round-trip. See [Standby Versions & Instant Rollback](spicepodset.md#standby-versions-and-instant-rollback).
+
+### Scale and pause
+
+Change `replicas` to scale. Set `replicas: 0` to pause the workload while retaining the Service, ConfigMap, ServiceAccount, and any user-supplied NetworkPolicy:
+
+```yaml
+spec:
+  replicas: 0
+```
+
+### Force a rollout
+
+`annotations` and `labels` propagate to every managed resource. Changing either triggers a full rollout — a convenient restart mechanism:
+
+```yaml
+spec:
+  annotations:
+    rollout-trigger: "2024-06-01T12:00:00Z"
+  labels:
+    environment: production
+```
+
+Operator-reserved `spice.ai/*` keys are rejected by the admission controller on `spec.labels` / `spec.annotations`.
+
+### Tune health probes and scheduling
+
+```yaml
+spec:
+  probes:
+    liveness:
+      initialDelaySeconds: 10
+      periodSeconds: 30
+    readiness:
+      initialDelaySeconds: 5
+      periodSeconds: 10
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/arch
+              operator: In
+              values: [amd64]
+  tolerations:
+    - key: dedicated
+      operator: Equal
+      value: spice
+      effect: NoSchedule
+  terminationGracePeriodSeconds: 30
+```
+
+## 4. Deploy a distributed cluster
+
+For query workloads that benefit from dedicated scheduler and executor nodes, use a `SpicepodCluster`. The operator provisions mTLS certificates and manages child `SpicepodSet`s automatically:
+
+```yaml
+apiVersion: spice.ai/v2beta1
+kind: SpicepodCluster
+metadata:
+  name: my-cluster
+  namespace: default
+spec:
+  schedulerSpec:
+    replicas: 1
+    spicepod:
+      name: my-cluster-scheduler
+      kind: Spicepod
+      version: v1
+  executorSpec:
+    replicas: 3
+```
+
+Executors pull their Spicepod configuration from the scheduler, so `executorSpec` needs no `spicepod` field. See the [SpicepodCluster reference](spicepodcluster.md) for mTLS, port separation, and per-node overrides.
+
+## 5. Inject a sidecar into an existing Pod
+
+To add a Spice sidecar to any existing Pod, annotate its template and point at a `ConfigMap` holding `spicepod.yaml`:
+
+```yaml
+template:
+  metadata:
+    annotations:
+      spice.ai/inject: "true"
+      spice.ai/inject-config: demo-spice-config
+```
+
+The ConfigMap must exist before the Pod is created. See [Sidecar Injection](README.md#sidecar-injection) for all supported annotations.
+
+## 6. Monitor and inspect status
+
+`kubectl` works natively thanks to standard status conditions:
+
+```bash
+kubectl get spicepodset
+kubectl wait spicepodset/my-spicepod --for=condition=Ready
+
+# Operator HTTP status API (port 8090)
+kubectl -n spiceai-operator-system port-forward deploy/spiceai-operator 8090:8090
+curl http://localhost:8090/default/my-spicepod
+```
+
+The status API returns per-pod details (phase, IP, Spiced health/readiness, error reasons). Paused `SpicepodSet`s report `paused: true` with a `pauseReason`. For operator self-telemetry over Prometheus and OTLP, see [Operator Metrics](metrics.md).
+
+## 7. Crashloop protection
+
+The operator monitors pods for repeated failures and, when the configured threshold is exceeded, pauses the workload (`replicas → 0`), sets `status.pauseReason = CrashLooping`, and emits a Warning event. Configure the threshold with the Helm value `pauseCrashloopingPodsThreshold` (the chart ships `0`, disabled, by default). To recover, fix the configuration and set `replicas` back to the desired count.
+
+## 8. Upgrade the operator
+
+```bash
+helm upgrade spiceai-operator \
+  oci://709825985650.dkr.ecr.us-east-1.amazonaws.com/spice-ai/charts/spiceai-operator \
+  --namespace spiceai-operator-system \
+  --values my-values.yaml
+```
+
+`v2beta1` is served with automatic conversion of legacy resources, so existing `SpicepodSet` / `SpicepodCluster` manifests continue to apply after the upgrade.
+
+## Next steps
+
+- [SpicepodSet reference](spicepodset.md) — every `SpicepodSet` field.
+- [SpicepodCluster reference](spicepodcluster.md) — distributed clusters and mTLS.
+- [Operator Metrics](metrics.md) — Prometheus scraping and OTLP push.
+- [Overview](README.md) — installation, Helm values, CLI, and roadmap.

--- a/enterprise/kubernetes/user-guide.md
+++ b/enterprise/kubernetes/user-guide.md
@@ -28,7 +28,7 @@ helm install spiceai-operator \
   --namespace spiceai-operator-system --create-namespace
 ```
 
-The chart installs the `SpicepodSet` and `SpicepodCluster` CRDs by default (`installCRDs: true`). Verify the controller is running:
+The chart installs the `SpicepodSet` and `SpicepodCluster` CRDs by default (`crds.enabled: true`). Verify the controller is running:
 
 ```bash
 kubectl -n spiceai-operator-system get pods
@@ -156,16 +156,18 @@ The Spicepod YAML supports `${secrets:KEY}` references to Kubernetes Secret valu
 
 ### Add persistent storage
 
-Attach a per-replica volume with `volumeClaimTemplate`; the operator creates a `PersistentVolumeClaim` per `StatefulSet`, mounted at `/data`:
+Attach per-replica volumes with the `volumeClaimTemplates` list; the operator creates a `PersistentVolumeClaim` per entry, per `StatefulSet`. The entry named `data` (the default when `metadata.name` is omitted) is auto-mounted at `/data`:
 
 ```yaml
 spec:
-  volumeClaimTemplate:
-    spec:
-      storageClassName: standard
-      resources:
-        requests:
-          storage: 10Gi
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        storageClassName: standard
+        resources:
+          requests:
+            storage: 10Gi
 ```
 
 Increasing the storage request triggers automatic PVC resizing when the `StorageClass` has `allowVolumeExpansion: true`. Shrinking is not supported.

--- a/enterprise/kubernetes/user-guide.md
+++ b/enterprise/kubernetes/user-guide.md
@@ -8,7 +8,7 @@ icon: book-open
 This guide walks through deploying and operating Spice.ai on Kubernetes with the operator — from installing the controller to configuring storage, networking, rollouts, scaling, and observability. For exhaustive field references, see [SpicepodSet](spicepodset.md) and [SpicepodCluster](spicepodcluster.md).
 
 {% hint style="info" %}
-All manifests below use the current `spice.ai/v2beta1` API version. Existing `spice.ai/v1` / `spice.ai/v1alpha1` manifests continue to apply and are converted automatically — see [Migrating from `spice.ai/v1`](spicepodset.md#migrating-from-spiceaiv1).
+All manifests below use the current `spice.ai/v2` API version. Existing `spice.ai/v1` / `spice.ai/v1alpha1` manifests continue to apply and are converted automatically — see [Migrating from `spice.ai/v1`](spicepodset.md#migrating-from-spiceaiv1).
 {% endhint %}
 
 ## Prerequisites
@@ -42,7 +42,7 @@ See the [Overview](README.md#helm-values) for the full list of Helm values.
 A `SpicepodSet` is the simplest way to run a Spicepod. Create `spicepodset.yaml`:
 
 ```yaml
-apiVersion: spice.ai/v2beta1
+apiVersion: spice.ai/v2
 kind: SpicepodSet
 metadata:
   name: my-spicepod
@@ -289,7 +289,7 @@ spec:
 For query workloads that benefit from dedicated scheduler and executor nodes, use a `SpicepodCluster`. The operator provisions mTLS certificates and manages child `SpicepodSet`s automatically:
 
 ```yaml
-apiVersion: spice.ai/v2beta1
+apiVersion: spice.ai/v2
 kind: SpicepodCluster
 metadata:
   name: my-cluster
@@ -349,7 +349,7 @@ helm upgrade spiceai-operator \
   --values my-values.yaml
 ```
 
-`v2beta1` is served with automatic conversion of legacy resources, so existing `SpicepodSet` / `SpicepodCluster` manifests continue to apply after the upgrade.
+`v2` is served with automatic conversion of legacy resources, so existing `SpicepodSet` / `SpicepodCluster` manifests continue to apply after the upgrade.
 
 ## Next steps
 


### PR DESCRIPTION
## Summary

Updates the enterprise Kubernetes Operator documentation for the **v1.0.0** release and the unified **`spice.ai/v2`** API. Migrates the existing reference pages, adds a task-oriented User Guide and an Operator Metrics page, and wires the new pages into navigation.

## Changes

**Reference pages migrated to `spice.ai/v2`**
- `SpicepodSet` and `SpicepodCluster`: StatefulSet-only deployment model, structured `spicepod` object, nested `http`/`flight`/`metrics` ports, `volumeClaimTemplate`, opt-in `NetworkPolicy`, SHA-based `standbyVersion` / instant rollback, admission validation, status conditions, and field-by-field migration tables. (`schedulerSetSpec`/`executorSetSpec` -> `schedulerSpec`/`executorSpec`; updated cluster status cert fields.)

**Overview**
- `README.md`: both CRDs to `v2`, refreshed Helm values, features table, sidecar injection annotations (`spice.ai/inject` boolean + `spice.ai/inject-config`), renamed operator CLI flags, GHCR install note, and a roadmap section.

**New pages**
- User Guide — install -> deploy -> configure -> distributed cluster -> sidecar -> monitor -> upgrade walkthrough.
- Operator Metrics — Prometheus scraping + opt-in OTLP push, `OTEL_*` env vars, temporality/vendor guidance, and a collector example.

**Navigation**
- Added User Guide and Operator Metrics to `enterprise/SUMMARY.md`.

## Notes

- Documents the **StatefulSet-only** model per the v1.0.0 release notes/changelog (superseding the prior "adaptive Deployment" text).
- All pages are markdownlint-clean (table alignment + fence languages); cross-page anchors verified.
- A couple of illustrative specifics (e.g. the operator Deployment name used in `kubectl port-forward`, exact `telemetry.otlp.*` Helm keys) were inferred from conventions and may be worth a quick check against the chart.